### PR TITLE
Add documenteer.sphinext to technote sphinx extension list

### DIFF
--- a/documenteer/designdocs/ddconfig.py
+++ b/documenteer/designdocs/ddconfig.py
@@ -109,7 +109,8 @@ def _build_confs(metadata):
                        'sphinx.ext.mathjax',
                        'sphinx.ext.ifconfig',
                        'sphinx-prompt',
-                       'sphinxcontrib.bibtex']
+                       'sphinxcontrib.bibtex',
+                       'documenteer.sphinxext']
 
     # The suffix(es) of source filenames.
     # You can specify multiple suffix as a list of string:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/documenteer'
-version = '0.1.5'
+version = '0.1.6'
 
 
 def read(filename):


### PR DESCRIPTION
This lets technotes use Sphinx extensions from documenteer itself.