### PR TITLE
DM-6196: Obtain revision date and version from Git if not specified in metadata.yaml

### DIFF
--- a/documenteer/designdocs/ddconfig.py
+++ b/documenteer/designdocs/ddconfig.py
@@ -12,6 +12,8 @@ from __future__ import unicode_literals
 import datetime
 import yaml
 
+import git
+
 import lsst_dd_rtd_theme
 
 
@@ -69,6 +71,18 @@ def configure_sphinx_design_doc(meta_stream):
     return confs
 
 
+def read_git_branch():
+    """Obtain the current branch name from the Git repository."""
+    repo = git.repo.base.Repo(search_parent_directories=True)
+    return repo.active_branch.name
+
+
+def read_git_commit_timestamp():
+    """Obtain the timestamp from the current git commit."""
+    repo = git.repo.base.Repo(search_parent_directories=True)
+    return repo.head.commit.committed_datetime
+
+
 def _build_confs(metadata):
     c = {}
 
@@ -79,8 +93,14 @@ def _build_confs(metadata):
 
     c['copyright'] = metadata['copyright']
 
-    # Short version name
-    c['version'] = metadata['version']
+    if 'version' in metadata:
+        c['version'] = metadata['version']
+    else:
+        # attempt to obtain the version as the Git branch
+        try:
+            c['version'] = read_git_branch()
+        except:
+            c['version'] = ''
 
     # The full version, including alpha/beta/rc tags.
     if 'dev_version_suffix' in metadata:
@@ -88,12 +108,16 @@ def _build_confs(metadata):
     else:
         c['release'] = c['version']
 
+    # Add a version suffix, if available
+    if 'dev_version_suffix' in metadata:
+        c['release'] = ''.join((c['release'], metadata['dev_version_suffix']))
+
     if 'last_revised' in metadata:
-        c['today'] = metadata['last_revised']
+        date = datetime.datetime.strptime(metadata['last_revised'], '%Y-%m-%d')
     else:
-        now = datetime.datetime.now()
-        now = now.replace(microsecond=0)
-        c['today'] = now.isoformat()
+        # obain date from git commit at HEAD
+        date = read_git_commit_timestamp()
+    c['today'] = date.strftime('%B %d, %Y')
 
     # This is available to Jinja2 templates
     c['html_context'] = {'author_list': metadata['authors'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ future>=0.15.2
 sphinx-prompt>=1.0.0
 PyYAML>=3.11
 sphinxcontrib-bibtex>=0.3.4
+GitPython>=2.0.6
 pytest>=2.9.1
 pytest-cov>=2.2.1
 pytest-flake8>=0.5

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/documenteer'
-version = '0.1.7'
+version = '0.1.8'
 
 
 def read(filename):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     keywords='sphinx documentation lsst',
     packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=['future', 'Sphinx', 'PyYAML', 'sphinx-prompt',
-                      'sphinxcontrib-bibtex'],
+                      'sphinxcontrib-bibtex', 'gitpython'],
     tests_require=['pytest', 'pytest-cov', 'pytest-flake8', 'pytest-mock'],
     # package_data={},
 )


### PR DESCRIPTION
If last_revised and version are not present in metadata.yaml, then the Git commit date and branch name should be used while building metadata instead.