### PR TITLE
DM-6120: v0.1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,14 @@ install:
   - pip install -e .
 script:
   - py.test --flake8 --cov=documenteer
+deploy:
+  provider: pypi
+  user: sqre-admin
+  skip_upload_docs: true
+  distributions: sdist bdist_wheel
+  password:
+    # PyPI deployment credentials for sqre-admin
+    secure: "g8YSFDE7Bc+DGC6VoI+9UX9oS7ucEu42XxkC+CBzc20seWldaLL7uL2roNJTKTqb8lq7m7eWxub25XTKjlBMYbeu53djmbAAvwhiwjG68PMHlA6RF10Sk05wChjhK7QwFMXXQ82jsDOtI/o5wgxinjR7WBXvFyA94LAkpTIErN3GMy5X3HAEl8X9XhvF+NUu3UfJni6dboSISJomTmP9BMRUqIzoQAs5OGHK6GTy+A0Im/cTYcd2B7vQMqkGVTsaB0NIv+HeCkFqUP0okwfLZTO13IqEfBf7N+xHir47f1ecsBKvppIHn58ypG8bM9A7YTndIX4gKQxYgGPQGIKJ1Y957pHr12EIkAn3bfToTQhmyCsPWLMFaQbmti5fdVUVsAuPRivWtf2O4NI8DvNj/F+zyGQ1BOaaiO4Oe4WWdZrtyk+B53RJvNCjcEE3g9gVHauaZ9bhxjN2fV7YdVL9vt0o6WFyhQrNDM3N9oQ2Fh3614ZAEi2/XaXOsgoLoV+NbgD3f6fMRwpnmtF+lt6QmWIUM9L9OZp3nQZ59lUPtnAjvSJOwYaKzNNnYBSJkLdCSzpeyWGemCxTGIPkVWjouOm45P3Q2VGwuoy4T5uPFrfL2h1U0MLxfARdLzgz40p7J1/gYrN7ZzEqxA8xq6B90SM1rFTm8IFzalFOnl0iuXY="
+  on:
+    tags: true
+    repo: lsst-sqre/documenteer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog for documenteer
 =========================
 
+0.1.11 (2017-03-01)
+-------------------
+
+- Add ``documenteer.sphinxconfi.utils.form_ltd_edition_name`` to form LSST the Docs-like edition names for Git refs.
+- Configure automated PyPI deployments with Travis.
+
 0.1.10 (2016-12-14)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -15,40 +15,31 @@ Documentation tools for `LSST Data Management <http://dm.lsst.org>`_ projects, i
 Installation
 ============
 
-.. code-block:: bash
+::
 
    pip install documenteer
 
 Development
 ===========
 
-Create a virtual environment with your method of choice (virtualenvwrapper or conda) and then clone or fork, and install:
-
-.. code-block:: bash
+Create a virtual environment with your method of choice (virtualenvwrapper or conda) and then clone or fork, and install::
 
    git clone https://github.com/lsst-sqre/documenteer.git
    pip install -r requirements.txt
 
 To make a release:
 
-1. Update the :file:`CHANGELOG.rst`.
-2. Increment version in :file:`setup.py`.
-3. Tag: ``git tag -s -m "Version X.Y.Z" vX.Y.Z``
-4. Build:
+1. Update ``CHANGELOG.rst``.
+2. Increment version in ``setup.py``.
+3. Tag: ``git tag -s -m "vX.Y.Z" vX.Y.Z``
+4. Push: ``git push --tags``
 
-   .. code-block:: bash
+`Travis <https://travis-ci.org/lsst-sqre/documenteer>`_ should handle the PyPI deployment.
 
-      rm -R dist
-      python setup.py sdist bdist_wheel
+License and info
+================
 
-5. Upload:
+Copyright 2015-2017 Association of Universities for Research in Astronomy, Inc.
 
-   .. code-block:: bash
-
-      twine upload dist/*
-      git push --tags
-
-License
-=======
-
-MIT Licensed. See :file:`LICENSE` and :file:`COPYRIGHT`.
+MIT licensed.
+See `LICENSE <./LICENSE>`_ and `COPYRIGHT <./COPYRIGHT>`.

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -3,8 +3,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import re
+
 import os
 import git
+
+
+TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)$')
+
+# does it start with vN and look like a version tag?
+TAG_PATTERN = re.compile('^v\d')
 
 
 def read_git_branch():
@@ -25,3 +33,46 @@ def read_git_commit_timestamp():
     """Obtain the timestamp from the current git commit."""
     repo = git.repo.base.Repo(search_parent_directories=True)
     return repo.head.commit.committed_datetime
+
+
+def form_ltd_edition_name(git_ref_name=None):
+    """Form the LSST the Docs edition name for this branch, using the same
+    logic as LTD Keeper does for transforming branch names into edition names.
+
+    Parameters
+    ----------
+    git_ref_name : `str`
+       Name of the git branch (or git ref, in general, like a tag) that.
+
+    Notes
+    -----
+    The LTD Keeper (github.com/lsst-sqre/ltd-keeper) logic is being replicated
+    here because Keeper is server side code and this is client-side and it's
+    not yet clear this warrants being refactored into a common dependency.
+
+    See ``keeper.utils.auto_slugify_edition``.
+    """
+    if git_ref_name is None:
+        name = read_git_branch()
+    else:
+        name = git_ref_name
+
+    # First, try to use the JIRA ticket number
+    m = TICKET_BRANCH_PATTERN.match(name)
+    if m is not None:
+        return m.group(1)
+
+    # Or use a tagged version
+    m = TAG_PATTERN.match(name)
+    if m is not None:
+        return name
+
+    if name == 'master':
+        # using this terminology for LTD Dasher
+        name = 'Current'
+
+    # Otherwise, reproduce the LTD slug
+    name = name.replace('/', '-')
+    name = name.replace('_', '-')
+    name = name.replace('.', '-')
+    return name

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ author = 'Jonathan Sick'
 author_email = 'jsick@lsst.org'
 license = 'MIT'
 url = 'https://github.com/lsst-sqre/documenteer'
-version = '0.1.10'
+version = '0.1.11'
 
 
 def read(filename):

--- a/tests/test_sphinxconfig_utils.py
+++ b/tests/test_sphinxconfig_utils.py
@@ -1,0 +1,16 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import pytest
+
+from documenteer.sphinxconfig.utils import form_ltd_edition_name
+
+
+@pytest.mark.parametrize("git_ref,name", [
+    ('master', 'Current'),
+    ('tickets/DM-6120', 'DM-6120'),
+    ('v1.2.3', 'v1.2.3'),
+    ('draft/v1.2.3', 'draft-v1-2-3'),
+])
+def test_form_ltd_edition_name(git_ref, name):
+    assert name == form_ltd_edition_name(git_ref_name=git_ref)


### PR DESCRIPTION
- Add auto deployment to PyPI via Travis
- Add `form_ltd_edition_name()` function to make friendly version strings.