### PR TITLE
DM-11334: Technote configuration improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Rename configuration function for technotes: ``documenteer.sphinxconfig.technoteconfig.configure_sphinx_design_doc`` is now ``documenteer.sphinxconfig.technoteconfig.configure_technote``.
+
 0.2.0 (2017-07-20)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,15 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.2.1 (2017-07-21)
+------------------
 
-- Rename configuration function for technotes: ``documenteer.sphinxconfig.technoteconfig.configure_sphinx_design_doc`` is now ``documenteer.sphinxconfig.technoteconfig.configure_technote``.
+- Rename configuration function for technotes: ``documenteer.sphinxconfig.technoteconfig.configure_sphinx_design_doc`` is now ``documenteer.sphinxconfig.technoteconf.configure_technote``.
+- Sphinx is no longer in the default intersphinx object list for technotes.
+  This will speed up builds for documents that don't refer to Python APIs, and it still straightforward to configure on a per-project basis.
+- The default revision timestamp for technotes is now derived from the most recent Git commit that modified a technote's content ('rst', and common image file formats).
+  This is implemented with the new ``documenteer.sphinxconfig.utils.get_project_content_commit_date()`` function.
+  This feature allows us to change technote infrastructure without automatically bumping the default revision date of the technote.
 
 0.2.0 (2017-07-20)
 ------------------

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -1,10 +1,10 @@
 """Sphinx configuration bootstrapping for LSST Technical Notes.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import (absolute_import,
+                        division,
+                        print_function,
+                        unicode_literals)
 
 import datetime
 import yaml

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -11,7 +11,9 @@ import yaml
 
 import lsst_dd_rtd_theme
 
-from ..sphinxconfig.utils import read_git_branch, read_git_commit_timestamp
+from ..sphinxconfig.utils import (
+    read_git_branch,
+    get_project_content_commit_date)
 
 
 def configure_technote(meta_stream):
@@ -97,8 +99,8 @@ def _build_confs(metadata):
     if 'last_revised' in metadata:
         date = datetime.datetime.strptime(metadata['last_revised'], '%Y-%m-%d')
     else:
-        # obain date from git commit at HEAD
-        date = read_git_commit_timestamp()
+        # obain date from git commit at most recent content commit since HEAD
+        date = get_project_content_commit_date()
     c['today'] = date.strftime('%Y-%m-%d')
 
     # This is available to Jinja2 templates

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -138,7 +138,9 @@ def _build_confs(metadata):
     c['todo_include_todos'] = True
 
     # Configuration for Intersphinx
-    c['intersphinx_mapping'] = {'https://docs.python.org/': None}
+    c['intersphinx_mapping'] = {}
+    # Add Python 3 intersphinx inventory in projects via
+    # c['intersphinx_mapping']['python'] = ('https://docs.python.org/3', None)
 
     # -- Options for HTML output ----------------------------------------------
 

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -14,7 +14,7 @@ import lsst_dd_rtd_theme
 from ..sphinxconfig.utils import read_git_branch, read_git_commit_timestamp
 
 
-def configure_sphinx_design_doc(meta_stream):
+def configure_technote(meta_stream):
     """
     Builds a ``dict`` of Sphinx configuration variables given a central
     configuration for LSST Design Documents and a metadata YAML file.
@@ -27,11 +27,11 @@ def configure_sphinx_design_doc(meta_stream):
     .. code:: python
 
        import os
-       from documenteer.designdocs import configure_sphinx_design_doc
+       from documenteer.sphinxconfig.technoteconf import configure_technote
 
        metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
        with open(metadata_path, 'r') as f:
-           confs = configure_sphinx_design_doc(f)
+           confs = configure_technote(f)
        _g = global()
        _g.update(confs)
 

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -81,6 +81,42 @@ def read_git_commit_timestamp_for_file(filepath, repo_path=None):
     raise IOError('File {} not found'.format(filepath))
 
 
+def get_filepaths_with_extension(extname, root_dir='.'):
+    """Get relative filepaths of files in a directory, and sub-directories,
+    with the given extension.
+
+    Parameters
+    ----------
+    extname : `str`
+        Extension name (e.g. 'txt', 'rst'). Extension comparison is
+        case-insensitive.
+    root_dir : 'str`, optional
+        Root directory. Current working directory by default.
+
+    Return
+    ------
+    filepaths : `list` of `str`
+        File paths, relative to ``root_dir``, with the given extension.
+    """
+    # needed for comparison with os.path.splitext
+    if not extname.startswith('.'):
+        extname = '.' + extname
+
+    # for case-insensitivity
+    extname = extname.lower()
+
+    root_dir = os.path.abspath(root_dir)
+
+    selected_filenames = []
+    for dirname, sub_dirnames, filenames in os.walk(root_dir):
+        for filename in filenames:
+            if os.path.splitext(filename)[-1].lower() == extname:
+                full_filename = os.path.join(dirname, filename)
+                selected_filenames.append(
+                    os.path.relpath(full_filename, start=root_dir))
+    return selected_filenames
+
+
 def form_ltd_edition_name(git_ref_name=None):
     """Form the LSST the Docs edition name for this branch, using the same
     logic as LTD Keeper does for transforming branch names into edition names.

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -29,10 +29,56 @@ def read_git_branch():
             return ''
 
 
-def read_git_commit_timestamp():
-    """Obtain the timestamp from the current git commit."""
-    repo = git.repo.base.Repo(search_parent_directories=True)
-    return repo.head.commit.committed_datetime
+def read_git_commit_timestamp(repo_path=None):
+    """Obtain the timestamp from the current head commit of a Git repository.
+
+    Parameters
+    ----------
+    repo_path : `str`, optional
+        Path to the Git repository. Leave as `None` to use the current working
+        directory.
+
+    Returns
+    -------
+    commit_timestamp : `datetime.datetime`
+        The datetime of the head commit.
+    """
+    repo = git.repo.base.Repo(path=repo_path, search_parent_directories=True)
+    head_commit = repo.head.commit
+    return head_commit.committed_datetime
+
+
+def read_git_commit_timestamp_for_file(filepath, repo_path=None):
+    """Obtain the timestamp for the most recent commit to a given file in a
+    Git repository.
+
+    Parameters
+    ----------
+    filepath : `str`
+        Repository-relative path for a file.
+    repo_path : `str`, optional
+        Path to the Git repository. Leave as `None` to use the current working
+        directory.
+
+    Returns
+    -------
+    commit_timestamp : `datetime.datetime`
+        The datetime of a the most recent commit to the given file.
+
+    Raises
+    ------
+    IOError
+        Raised if the ``filepath`` does not exist in the Git repository.
+    """
+    repo = git.repo.base.Repo(path=repo_path, search_parent_directories=True)
+    head_commit = repo.head.commit
+
+    # most recent commit datetime of the given file
+    for commit in head_commit.iter_parents(filepath):
+        return commit.committed_datetime
+
+    # Only get here if git could not find the file path in the history
+    raise IOError('File {} not found'.format(filepath))
 
 
 def form_ltd_edition_name(git_ref_name=None):

--- a/tests/test_sphinxconfig_utils.py
+++ b/tests/test_sphinxconfig_utils.py
@@ -9,7 +9,8 @@ import pytest
 from documenteer.sphinxconfig.utils import (
     form_ltd_edition_name, read_git_commit_timestamp,
     read_git_commit_timestamp_for_file,
-    get_filepaths_with_extension)
+    get_filepaths_with_extension,
+    get_project_content_commit_date)
 
 
 @pytest.mark.parametrize("git_ref,name", [
@@ -54,3 +55,12 @@ def test_get_filepaths_with_extension():
     filepaths = get_filepaths_with_extension('py', root_dir=repo_dir)
     assert os.path.join('tests', 'test_sphinxconfig_utils.py') in filepaths
     assert 'README.rst' not in filepaths
+
+
+def test_get_project_content_commit_date():
+    """Smoke test using the documenteer repo.
+    """
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    print('repo_dir', repo_dir)
+    commit_date = get_project_content_commit_date(root_dir=repo_dir)
+    assert isinstance(commit_date, datetime)

--- a/tests/test_sphinxconfig_utils.py
+++ b/tests/test_sphinxconfig_utils.py
@@ -8,7 +8,8 @@ import pytest
 
 from documenteer.sphinxconfig.utils import (
     form_ltd_edition_name, read_git_commit_timestamp,
-    read_git_commit_timestamp_for_file)
+    read_git_commit_timestamp_for_file,
+    get_filepaths_with_extension)
 
 
 @pytest.mark.parametrize("git_ref,name", [
@@ -46,3 +47,10 @@ def test_git_commit_timestamp_for_file_nonexistent():
     path = 'doesnt_exist.txt'
     with pytest.raises(IOError):
         read_git_commit_timestamp_for_file(path)
+
+
+def test_get_filepaths_with_extension():
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    filepaths = get_filepaths_with_extension('py', root_dir=repo_dir)
+    assert os.path.join('tests', 'test_sphinxconfig_utils.py') in filepaths
+    assert 'README.rst' not in filepaths

--- a/tests/test_sphinxconfig_utils.py
+++ b/tests/test_sphinxconfig_utils.py
@@ -1,9 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from datetime import datetime
+import os
+
 import pytest
 
-from documenteer.sphinxconfig.utils import form_ltd_edition_name
+from documenteer.sphinxconfig.utils import (
+    form_ltd_edition_name, read_git_commit_timestamp,
+    read_git_commit_timestamp_for_file)
 
 
 @pytest.mark.parametrize("git_ref,name", [
@@ -14,3 +19,30 @@ from documenteer.sphinxconfig.utils import form_ltd_edition_name
 ])
 def test_form_ltd_edition_name(git_ref, name):
     assert name == form_ltd_edition_name(git_ref_name=git_ref)
+
+
+def test_git_commit_timestamp():
+    """Smoke-test read_git_commit_timestamp using Documenteer's own Git
+    repository.
+    """
+    timestamp = read_git_commit_timestamp()
+    assert isinstance(timestamp, datetime)
+
+
+def test_git_commit_timestamp_for_file():
+    """Smoke-test read_git_commit_timestamp_for_file with README.rst in
+    Documenteer's own Git repo.
+    """
+    test_dir = os.path.dirname(__file__)
+    readme_path = os.path.abspath(os.path.join(test_dir, '..', 'README.rst'))
+    timestamp = read_git_commit_timestamp_for_file(readme_path)
+    assert isinstance(timestamp, datetime)
+
+
+def test_git_commit_timestamp_for_file_nonexistent():
+    """Smoke-test read_git_commit_timestamp_for_file with README.rst in
+    Documenteer's own Git repo.
+    """
+    path = 'doesnt_exist.txt'
+    with pytest.raises(IOError):
+        read_git_commit_timestamp_for_file(path)

--- a/tests/test_technoteconf.py
+++ b/tests/test_technoteconf.py
@@ -46,8 +46,8 @@ def test_git_last_revised(monkeypatch, mocker, sample_metadata,
                           input, expected):
     monkeypatch.setenv('TRAVIS', 'false')
     import documenteer.sphinxconfig.technoteconf as technoteconf
-    technoteconf.read_git_commit_timestamp = mocker.MagicMock()
-    technoteconf.read_git_commit_timestamp.return_value = input
+    technoteconf.get_project_content_commit_date = mocker.MagicMock()
+    technoteconf.get_project_content_commit_date.return_value = input
 
     sample_metadata.pop('last_revised')
 


### PR DESCRIPTION
- Rename the configuration function for technotes: `documenteer.sphinxconfig.technoteconfig.configure_sphinx_design_doc` is now `documenteer.sphinxconfig.technoteconfig.configure_technote`.
- Sphinx is no longer in the default intersphinx object list for technotes.
  This will speed up builds for documents that don't refer to Python APIs, and is still straightforward to configure on a per-project basis.
- The default revision timestamp for technotes is now derived from the most recent Git commit that modified a technote's content ('rst', and common image file formats).
  This is implemented with the new `documenteer.sphinxconfig.utils.get_project_content_commit_date` function.
  This feature allows us to change technote infrastructure without automatically bumping the default revision date of the technote.
