### PR TITLE
DM-6033: Support for lsst-texmf bibliographies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Unreleased
 
 - Add ``documenteer.sphinxext.bibtex`` extension to support LSST BibTeX entries that include a ``docushare`` field.
   Originally from `lsst-texmf`_.
+- Add a ``refresh-lsst-bib`` command line program that downloads the latest LSST bib files from the `lsst-texmf`_ GitHub repository.
+  This program can be used by technote authors to update a technote's local bibliography set at any time.
+- Add a dependency upon the Requests library.
 
 0.2.1 (2017-07-21)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,15 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.2.2 (2017-07-22)
+------------------
 
 - Add ``documenteer.sphinxext.bibtex`` extension to support LSST BibTeX entries that include a ``docushare`` field.
   Originally from `lsst-texmf`_.
+  This extension is active in the technote Sphinx configuration.
 - Add a ``refresh-lsst-bib`` command line program that downloads the latest LSST bib files from the `lsst-texmf`_ GitHub repository.
   This program can be used by technote authors to update a technote's local bibliography set at any time.
+- Added graceful defaults when a technote is being built without an underlying Git repository (catches exceptions from functions that seek Git metadata).
 - Add a dependency upon the Requests library.
 
 0.2.1 (2017-07-21)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Add ``documenteer.sphinxext.bibtex`` extension to support LSST BibTeX entries that include a ``docushare`` field.
+  Originally from `lsst-texmf`_.
+
 0.2.1 (2017-07-21)
 ------------------
 
@@ -91,3 +97,5 @@ Includes prototype support for LSST Science Pipelines documentation, as part of 
 ------------------
 
 - Initial version
+
+.. _lsst-texmf: https://github.com/lsst/lsst-texmf

--- a/documenteer/bin/refreshlsstbib.py
+++ b/documenteer/bin/refreshlsstbib.py
@@ -1,0 +1,124 @@
+"""Command line executable to refresh lsst bib files.
+"""
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from builtins import *  # noqa: F401, F403
+from future.standard_library import install_aliases
+install_aliases()  # noqa: E402
+
+import argparse
+import logging
+import os
+import sys
+import urllib
+
+import requests
+
+from .._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+
+
+def run():
+    """Command line entrypoint for the ``refresh-lsst-bib`` program.
+    """
+    args = parse_args()
+
+    if args.verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format='%(asctime)s %(levelname)s %(name)s: %(message)s')
+    if not args.verbose:
+        # Manage third-party loggers
+        req_logger = logging.getLogger('requests')
+        req_logger.setLevel(logging.WARNING)
+
+    logger = logging.getLogger(__name__)
+
+    logger.info('refresh-lsst-bib version {}'.format(__version__))
+
+    error_count = process_bib_files(args.dir)
+
+    sys.exit(error_count)
+
+
+def parse_args():
+    """Create an argument parser for the ``refresh-lsst-bib`` program.
+
+    Returns
+    -------
+    args : `argparse.Namespace`
+        Parsed argument object.
+    """
+    parser = argparse.ArgumentParser(
+        description="Download LSST .bib bibliography files from the "
+                    "lsst-texmf GitHub repository.",
+        epilog="Version {}".format(__version__)
+    )
+    parser.add_argument(
+        '-d', '--dir',
+        default='.',
+        help="Directory to download bib files into. Default is the current "
+             "workig directory.")
+    parser.add_argument(
+        '-v', '--verbose',
+        dest='verbose',
+        action='store_true', default=False,
+        help='Enable Verbose output (debug level logging)'
+    )
+    return parser.parse_args()
+
+
+def process_bib_files(local_dir):
+    """Run the refresh-lsst-bib program's logic: iterates through bib URLs,
+    downloads the file from GitHub, and writes it to a local directory.
+
+    Parameters
+    ----------
+    local_dir : `str`
+        Directory to write bib files into.
+
+    Returns
+    -------
+    error_count : `int`
+        Number of download errors.
+    """
+    logger = logging.getLogger(__name__)
+
+    # check the output directory exists
+    if not os.path.isdir(local_dir):
+        logger.error('Output directory "{}" does not exist'.format(local_dir))
+        sys.exit(1)
+
+    root_blob_url = ('https://raw.githubusercontent.com/lsst/lsst-texmf/'
+                     'master/texmf/bibtex/bib/')
+    bib_filenames = ['books.bib', 'lsst-dm.bib', 'lsst.bib', 'refs.bib',
+                     'refs_ads.bib']
+
+    error_count = 0
+    for bib_filename in bib_filenames:
+        url = urllib.parse.urljoin(root_blob_url, bib_filename)
+        logger.info('Downloading {}'.format(url))
+        try:
+            content = _get_content(url)
+        except requests.HTTPError as e:
+            logger.exception(str(e))
+            logger.warning('Could not download {}'.format(url))
+            error_count += 1
+            continue
+
+        local_filename = os.path.join(local_dir, bib_filename)
+        with open(local_filename, 'w') as f:
+            f.write(content)
+
+    return error_count
+
+
+def _get_content(url):
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.text

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -118,7 +118,8 @@ def _build_confs(metadata):
                        'sphinx.ext.ifconfig',
                        'sphinx-prompt',
                        'sphinxcontrib.bibtex',
-                       'documenteer.sphinxext']
+                       'documenteer.sphinxext',
+                       'documenteer.sphinxext.bibtex']
 
     # The suffix(es) of source filenames.
     # You can specify multiple suffix as a list of string:

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -84,7 +84,12 @@ def _build_confs(metadata):
         c['version'] = metadata['version']
     else:
         # attempt to obtain the version as the Git branch
-        c['version'] = read_git_branch()
+        try:
+            c['version'] = read_git_branch()
+        except Exception as e:
+            print('Caught exception: {}'.format(e))
+            print('Cannot get git branch information.')
+            c['version'] = 'Unknown'
 
     # The full version, including alpha/beta/rc tags.
     if 'dev_version_suffix' in metadata:
@@ -100,7 +105,12 @@ def _build_confs(metadata):
         date = datetime.datetime.strptime(metadata['last_revised'], '%Y-%m-%d')
     else:
         # obain date from git commit at most recent content commit since HEAD
-        date = get_project_content_commit_date()
+        try:
+            date = get_project_content_commit_date()
+        except Exception as e:
+            print('Caught exception: {}'.format(e))
+            print('Cannot get project content git commit date.')
+            date = datetime.datetime.now()
     c['today'] = date.strftime('%Y-%m-%d')
 
     # This is available to Jinja2 templates

--- a/documenteer/sphinxext/__init__.py
+++ b/documenteer/sphinxext/__init__.py
@@ -1,12 +1,17 @@
 """Sphinx/docutils extensions for LSST DM documentation.
 
-Enable these extension by adding `documenteer.sphinxext` to your
+Enable these extension by adding ``documenteer.sphinxext`` to your
 extensions list in :file:`conf.py`::
 
     extensions = [
        # ...
        'documenteer.sphinxext'
     ]
+
+Some extensions require project-specific dependencies and are not
+automatically enabled. They should be specified individually. They are:
+
+- ``documenteer.sphinxext.bibtex``
 """
 
 from . import jira, lsstdocushare, mockcoderefs

--- a/documenteer/sphinxext/bibtex.py
+++ b/documenteer/sphinxext/bibtex.py
@@ -1,0 +1,41 @@
+"""Extensions to support LSST bibliographies with
+`sphinxcontrib-bibtex <http://sphinxcontrib-bibtex.readthedocs.io>`_.
+"""
+
+from pybtex.style.formatting.plain import Style as PlainStyle
+from pybtex.style.formatting import toplevel
+from pybtex.plugin import register_plugin
+from pybtex.style.template import (
+    join, field, sentence, tag, optional_field, href, first_of, optional
+)
+
+
+class LsstBibtexStyle(PlainStyle):
+    """Bibtex style that understands ``docushare`` fields in LSST
+    bibliographies.
+    """
+
+    def format_docushare(self, e):
+        default_url = join['https://ls.st/', field('handle', raw=True)]
+
+        template = toplevel[
+            sentence[tag('b')['[', href[default_url, field('handle')], ']']],
+            self.format_names('author'),
+            self.format_title(e, 'title'),
+            sentence[field('year')],
+            sentence[optional_field('note')],
+            # Use URL if we have it, else provide own
+            first_of[
+                optional[
+                    self.format_url(e)
+                ],
+                # define our own URL
+                sentence['URL', href[default_url, default_url]]
+            ]
+        ]
+        return template.format_data(e)
+
+
+def setup(app):
+    """Add this plugin to the Sphinx application."""
+    register_plugin('pybtex.style.formatting', 'lsst_aa', LsstBibtexStyle)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_requires = [
     'Sphinx>=1.5.0,<1.6.0',
     'PyYAML',
     'sphinx-prompt',
-    'GitPython'
+    'GitPython',
+    'requests'
 ]
 
 
@@ -83,7 +84,8 @@ setup(
     extras_require=extras_require,
     entry_points={
         'console_scripts': [
-            'build-stack-docs = documenteer.stackdocs.build:run_build_cli'
+            'build-stack-docs = documenteer.stackdocs.build:run_build_cli',
+            'refresh-lsst-bib = documenteer.bin.refreshlsstbib:run'
         ]
     },
 )

--- a/tests/test_refreshlsstbib.py
+++ b/tests/test_refreshlsstbib.py
@@ -1,0 +1,20 @@
+"""Tests for the refresh-lsst-bib program.
+"""
+
+import os
+
+from documenteer.bin.refreshlsstbib import process_bib_files
+
+
+def test_process_bib_files(tmpdir):
+    """Smoke test that downloads and writes bib files into a pytest-fixtured
+    temp directory.
+    """
+    dirname = tmpdir.dirname
+    error_count = process_bib_files(dirname)
+    assert error_count == 0
+    assert os.path.exists(os.path.join(dirname, 'books.bib'))
+    assert os.path.exists(os.path.join(dirname, 'lsst-dm.bib'))
+    assert os.path.exists(os.path.join(dirname, 'lsst.bib'))
+    assert os.path.exists(os.path.join(dirname, 'refs.bib'))
+    assert os.path.exists(os.path.join(dirname, 'refs_ads.bib'))


### PR DESCRIPTION
- Add `LsstBibtexStyle` pybtex style to support DocuShare fields (from lsst-texmf originally).
- Add `refresh-lsst-bib` program to download lsst-bibtex files from GitHub (master branch). This is a lightweight way of helping people automatically update their lsst-bibtex files without the usability issues of submodules.