### PR TITLE
DM-11415: Additional roles for creating ls.st links to DocuShare handles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.2.3 (2017-07-28)
+------------------
+
+- Add support for additional DocuShare linking roles with ``documenteer.sphinxext.lsstdocushare``.
+  Supported handles now include: ``ldm``, ``lse``, ``lpm``, ``lts``, ``lep``, ``lca``, ``lsstc``, ``lcr``, ``lcn``, ``dmtr``, ``spt``, ``document``, ``report``, ``minutes``, ``collection``, ``sqr``, ``dmtn``, ``smtn``.
+- Links made by the ``documenteer.sphinxext.lsstdocushare`` extension are now HTTPS.
+- Pin the flake8 developer dependency to 3.3.0. Flake8 version 3.4 has changed how ``noqa`` comments are treated.
+
 0.2.2 (2017-07-22)
 ------------------
 

--- a/documenteer/sphinxext/lsstdocushare.py
+++ b/documenteer/sphinxext/lsstdocushare.py
@@ -1,26 +1,18 @@
-"""LSST Docushare reference roles."""
+"""LSST DocuShare/ls.st reference roles."""
 
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
-from builtins import *  # NOQA
+from builtins import *  # noqa: F401, F403
 from future.standard_library import install_aliases
-install_aliases()  # NOQA
-
-import logging
+install_aliases()  # noqa: E402
 
 from docutils import nodes
-
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 
 def lsst_doc_shortlink_role(name, rawtext, text, lineno, inliner,
                             options=None, content=None):
     """Link to LSST documents given their handle using LSST's ls.st link
     shortener.
-
-    Compatible with 'LDM,' 'LSE,' and 'LPM' documents.
 
     Example::
 
@@ -30,12 +22,64 @@ def lsst_doc_shortlink_role(name, rawtext, text, lineno, inliner,
     content = content or []
     node = nodes.reference(
         text='{0}-{1}'.format(name.upper(), text),
-        refuri='http://ls.st/{0}-{1}'.format(name, text),
+        refuri='https://ls.st/{0}-{1}'.format(name, text),
+        **options)
+    return [node], []
+
+
+def lsst_doc_shortlink_titlecase_display_role(
+        name, rawtext, text, lineno, inliner, options=None, content=None):
+    """Link to LSST documents given their handle using LSST's ls.st link
+    shortener with the document handle displayed in title case.
+
+    This role is useful for Document, Report, Minutes, and Collection
+    DocuShare handles.
+
+    Example::
+
+        :document:`1`
+    """
+    options = options or {}
+    content = content or []
+    node = nodes.reference(
+        text='{0}-{1}'.format(name.title(), text),
+        refuri='https://ls.st/{0}-{1}'.format(name, text),
         **options)
     return [node], []
 
 
 def setup(app):
+    # LSST Data Management
     app.add_role('ldm', lsst_doc_shortlink_role)
+    # LSST Systems Engineering
     app.add_role('lse', lsst_doc_shortlink_role)
+    # LSST Project Management
     app.add_role('lpm', lsst_doc_shortlink_role)
+    # LSST Telescope & Site
+    app.add_role('lts', lsst_doc_shortlink_role)
+    # LSST Education & Public Outreach
+    app.add_role('lep', lsst_doc_shortlink_role)
+    # LSST Camera System
+    app.add_role('lca', lsst_doc_shortlink_role)
+    # LSST Board
+    app.add_role('lsstc', lsst_doc_shortlink_role)
+    # LSST Change Request
+    app.add_role('lcr', lsst_doc_shortlink_role)
+    # LSST Camera Change Notice
+    app.add_role('lcn', lsst_doc_shortlink_role)
+    # LSST Data Management Test Report
+    app.add_role('dmtr', lsst_doc_shortlink_role)
+    # LSST Document
+    app.add_role('document', lsst_doc_shortlink_titlecase_display_role)
+    # LSST Report
+    app.add_role('report', lsst_doc_shortlink_titlecase_display_role)
+    # LSST Minutes
+    app.add_role('minutes', lsst_doc_shortlink_titlecase_display_role)
+    # DocuShare collection
+    app.add_role('collection', lsst_doc_shortlink_titlecase_display_role)
+    # LSST SQuaRE Technical Note
+    app.add_role('sqr', lsst_doc_shortlink_role)
+    # LSST Data Management Technical Note
+    app.add_role('dmtn', lsst_doc_shortlink_role)
+    # LSST Simulations Technical Note
+    app.add_role('smtn', lsst_doc_shortlink_role)

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ extras_require = {
         'pytest==3.0.4',
         'pytest-cov==2.4.0',
         'pytest-flake8==0.8.1',
-        'pytest-mock==1.4.0'
+        'pytest-mock==1.4.0',
+        'flake8==3.3.0'
     ]
 }
 

--- a/tests/test_sphinxext_lsstdocushare.py
+++ b/tests/test_sphinxext_lsstdocushare.py
@@ -1,4 +1,5 @@
-"""Tests for documenteer.sphinext.lsstdocushare."""
+"""Tests for `documenteer.sphinext.lsstdocushare`.
+"""
 
 
 from tempfile import mkdtemp
@@ -53,11 +54,20 @@ def inliner(app):
 
 @pytest.mark.parametrize(
     "test_input,expected",
-    [(('ldm', '151'), ('LDM-151', 'http://ls.st/ldm-151')),
-     (('lse', '123'), ('LSE-123', 'http://ls.st/lse-123')),
-     (('lpm', '123'), ('LPM-123', 'http://ls.st/lpm-123'))])
+    [(('ldm', '151'), ('LDM-151', 'https://ls.st/ldm-151')),
+     (('lse', '123'), ('LSE-123', 'https://ls.st/lse-123')),
+     (('lpm', '123'), ('LPM-123', 'https://ls.st/lpm-123')),
+     (('lts', '123'), ('LTS-123', 'https://ls.st/lts-123')),
+     (('lep', '123'), ('LEP-123', 'https://ls.st/lep-123')),
+     (('lsstc', '123'), ('LSSTC-123', 'https://ls.st/lsstc-123')),
+     (('lcr', '123'), ('LCR-123', 'https://ls.st/lcr-123')),
+     (('lcn', '123'), ('LCN-123', 'https://ls.st/lcn-123')),
+     (('dmtr', '123'), ('DMTR-123', 'https://ls.st/dmtr-123')),
+     (('sqr', '123'), ('SQR-123', 'https://ls.st/sqr-123')),
+     (('dmtn', '123'), ('DMTN-123', 'https://ls.st/dmtn-123')),
+     ])
 def test_shortlink(inliner, test_input, expected):
-
+    """Test that the link names and URL are correct."""
     name, content = test_input
     result = lsstdocushare.lsst_doc_shortlink_role(
         name=name,
@@ -65,8 +75,28 @@ def test_shortlink(inliner, test_input, expected):
         text=content,
         inliner=inliner,
         lineno=None)
-    print(expected)
-    print(result)
+    expected_text, expected_uri = expected
+    assert result[0][0].astext() == expected_text
+    assert result[0][0].attributes['refuri'] == expected_uri
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [(('document', '123'), ('Document-123', 'https://ls.st/document-123')),
+     (('minutes', '123'), ('Minutes-123', 'https://ls.st/minutes-123')),
+     (('collection', '123'),
+      ('Collection-123', 'https://ls.st/collection-123')),
+     ])
+def test_titlecase_shortlink(inliner, test_input, expected):
+    """Test that the link names and URL are correct for
+    roles made with `lsst_doc_shortlink_titlecase_display_role`."""
+    name, content = test_input
+    result = lsstdocushare.lsst_doc_shortlink_titlecase_display_role(
+        name=name,
+        rawtext=content,
+        text=content,
+        inliner=inliner,
+        lineno=None)
     expected_text, expected_uri = expected
     assert result[0][0].astext() == expected_text
     assert result[0][0].attributes['refuri'] == expected_uri


### PR DESCRIPTION
Support for

- LTS
- LEP
- LCA
- LSSTC
- LCR
- LCN
- DMTR
- SPT
- Document (displays in title case, Document-1)
- Report (displays in title case)
- Minutes (displays in title case)
- Collection (displays in title case)
- SQR
- DMTN
- SMTN