### PR TITLE
add ability to run tests without installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install:
-  - pip install -e ".[technote,pipelines,dev]"
 script:
-  - py.test --flake8 --cov=documenteer
+  - python setup.py test
 deploy:
   provider: pypi
   user: sqre-admin

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [flake8]
 max-line-length = 79
 exclude =
@@ -5,7 +8,7 @@ exclude =
   lander/_version.py
 
 [tool:pytest]
-addopts = --flake8
+addopts = --flake8 --cov=documenteer
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -53,14 +53,22 @@ extras_require = {
     'dev': [
         'wheel>=0.29.0',
         'twine>=1.8.1',
-        'pytest==3.0.4',
-        'pytest-cov==2.4.0',
-        'pytest-flake8==0.8.1',
-        'pytest-mock==1.4.0',
-        'flake8==3.3.0'
-    ]
+    ],
 }
 
+tests_require = [
+    'pytest==3.0.4',
+    'pytest-cov==2.4.0',
+    'pytest-flake8==0.8.1',
+    'pytest-mock==1.4.0',
+    'flake8==3.3.0',
+]
+for k in extras_require:
+    tests_require += extras_require[k]
+
+setup_requires = [
+    'pytest-runner>=2.11.1,<3',
+]
 
 setup(
     name=packagename,
@@ -82,6 +90,8 @@ setup(
     keywords='sphinx documentation lsst',
     packages=find_packages(exclude=['docs', 'tests*']),
     install_requires=install_requires,
+    setup_requires=setup_requires,
+    tests_require=tests_require,
     extras_require=extras_require,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This avoids unnecessarily polluting a development environment.

Eg., `python setup.py test`