### PR TITLE
DM-14053: Add package-toctree and module-toctree

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Add ``module-toctree`` and ``package-toctree`` directives.
+  These create toctrees for modules and packages, respectively, in Stack documentation sites like pipelines.lsst.io.
+  With these directives, we don't need to modify the ``index.rst`` file in https://github.com/lsst/pipelines_lsst_io each time new packages are added or removed.
+
 0.2.7 (2018-03-09)
 ------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2017 Association of Universities for Research in Astronomy, Inc.
+Copyright (c) 2015-2018 Association of Universities for Research in Astronomy, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/documenteer/sphinxext/__init__.py
+++ b/documenteer/sphinxext/__init__.py
@@ -14,7 +14,7 @@ automatically enabled. They should be specified individually. They are:
 - ``documenteer.sphinxext.bibtex``
 """
 
-from . import jira, lsstdocushare, mockcoderefs
+from . import jira, lsstdocushare, mockcoderefs, packagetoctree
 
 
 def setup(app):
@@ -23,3 +23,4 @@ def setup(app):
     jira.setup(app)
     lsstdocushare.setup(app)
     mockcoderefs.setup(app)
+    packagetoctree.setup(app)

--- a/documenteer/sphinxext/packagetoctree.py
+++ b/documenteer/sphinxext/packagetoctree.py
@@ -1,0 +1,185 @@
+"""Sphinx extensions for creating toctrees for packages and modules for the
+Pipelines documentation.
+"""
+
+__all__ = ('setup', 'ModuleTocTree', 'PackageTocTree')
+
+import docutils
+from docutils.parsers.rst import Directive
+import sphinx
+try:
+    # Sphinx 1.6+
+    from sphinx.util.logging import getLogger
+except ImportError:
+    getLogger = None
+from sphinx.util.nodes import set_source_info
+
+from .._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+
+
+class ModuleTocTree(Directive):
+    """Toctree that automatically displays a list of modules in the Stack
+    documentation.
+
+    Modules are detected as document paths. All modules have index pages
+    with paths ``modules/{{name}}/index`` by virtue of the linking during the
+    build process. Thus this directive does not directly interact with eups.
+    """
+
+    has_content = False
+
+    def run(self):
+        """Main entrypoint method.
+
+        Returns
+        -------
+        new_nodes : `list`
+            Nodes to add to the doctree.
+        """
+        if getLogger is not None:
+            # Sphinx 1.6+
+            logger = getLogger(__name__)
+        else:
+            # Previously Sphinx's app was also the logger
+            logger = self.state.document.settings.env.app
+
+        env = self.state.document.settings.env
+        new_nodes = []
+
+        # List of homepage documents for each module
+        module_index_files = []
+        entries = []
+
+        # Collect paths with the form `modules/<module-name>/index`
+        for docname in _filter_index_pages(env.found_docs, 'modules'):
+            module_index_files.append(docname)
+            entries.append((None, docname))
+            logger.debug('module-toctree found %s', docname)
+        logger.debug('module-toctree found %d modules',
+                     len(module_index_files))
+
+        # Add the toctree's node itself
+        subnode = _build_toctree_node(
+            parent=env.docname,
+            entries=entries,
+            includefiles=module_index_files,
+            caption=None)
+        set_source_info(self, subnode)  # Sphinx TocTree does this.
+
+        wrappernode = docutils.nodes.compound(classes=['toctree-wrapper',
+                                                       'module-toctree'])
+        wrappernode.append(subnode)
+        self.add_name(wrappernode)
+        new_nodes.append(wrappernode)
+
+        return new_nodes
+
+
+class PackageTocTree(Directive):
+    """Toctree that automatically lists packages in the Stack documentation.
+
+    Packages are detected as document paths. All packages have index pages
+    with paths ``packages/{{name}}/index`` by virtue of the linking during the
+    build process. Thus this directive does not directly interact with eups.
+    """
+
+    has_content = False
+
+    def run(self):
+        """Main entrypoint method.
+
+        Returns
+        -------
+        new_nodes : `list`
+            Nodes to add to the doctree.
+        """
+        if getLogger is not None:
+            # Sphinx 1.6+
+            logger = getLogger(__name__)
+        else:
+            # Previously Sphinx's app was also the logger
+            logger = self.state.document.settings.env.app
+
+        env = self.state.document.settings.env
+        new_nodes = []
+
+        # List of homepage documents for each package
+        package_index_files = []
+        entries = []
+
+        # Collect paths with the form `modules/<module-name>/index`
+        for docname in _filter_index_pages(env.found_docs, 'packages'):
+            package_index_files.append(docname)
+            entries.append((None, docname))
+            logger.debug('package-toctree found %s', docname)
+        logger.debug('package-toctree found %d packages',
+                     len(package_index_files))
+
+        # Add the toctree's node itself
+        subnode = _build_toctree_node(
+            parent=env.docname,
+            entries=entries,
+            includefiles=package_index_files,
+            caption=None)
+
+        set_source_info(self, subnode)  # Sphinx TocTree does this.
+
+        wrappernode = docutils.nodes.compound(classes=['toctree-wrapper',
+                                                       'package-toctree'])
+        wrappernode.append(subnode)
+        self.add_name(wrappernode)
+        new_nodes.append(wrappernode)
+
+        return new_nodes
+
+
+def _filter_index_pages(docnames, base_dir):
+    """Filter docnames to only yield paths of the form
+    ``<base_dir>/<name>/index``
+
+    Parameters
+    ----------
+    docnames : `list` of `str`
+        List of document names (``env.found_docs``).
+    base_dir : `str`
+        Base directory of all sub-directories containing index pages.
+
+    Yields
+    ------
+    docname : `str`
+        Document name that meets the pattern.
+    """
+    for docname in docnames:
+        parts = docname.split('/')
+        if len(parts) == 3 and parts[0] == base_dir and parts[2] == 'index':
+            yield docname
+
+
+def _build_toctree_node(parent=None, entries=None, includefiles=None,
+                        caption=None):
+    """Factory for a toctree node.
+    """
+    # Add the toctree's node itself
+    subnode = sphinx.addnodes.toctree()
+    subnode['parent'] = parent
+    subnode['entries'] = entries
+    subnode['includefiles'] = includefiles
+    subnode['caption'] = caption
+    # These values are needed for toctree node types. We don't need/want
+    # these to be configurable for module-toctree.
+    subnode['maxdepth'] = 1
+    subnode['hidden'] = False
+    subnode['glob'] = None
+    subnode['hidden'] = False
+    subnode['includehidden'] = False
+    subnode['numbered'] = 0
+    subnode['titlesonly'] = False
+    return subnode
+
+
+def setup(app):
+    app.add_directive('module-toctree', ModuleTocTree)
+    app.add_directive('package-toctree', PackageTocTree)
+    return {'version': __version__}

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ install_requires = [
     'requests'
 ]
 
-
 # Project-specific dependencies
 extras_require = {
     # For technical note Sphinx projects
@@ -52,16 +51,16 @@ extras_require = {
     'dev': [
         'wheel>=0.29.0',
         'twine>=1.8.1',
+        'pytest==3.0.4',
+        'pytest-cov==2.4.0',
+        'pytest-flake8==0.8.1',
+        'pytest-mock==1.4.0',
+        'flake8==3.3.0',
     ],
 }
 
-tests_require = [
-    'pytest==3.0.4',
-    'pytest-cov==2.4.0',
-    'pytest-flake8==0.8.1',
-    'pytest-mock==1.4.0',
-    'flake8==3.3.0',
-]
+# Dependencies for tests_require (python setup.py test)
+tests_require = []
 for k in extras_require:
     tests_require += extras_require[k]
 

--- a/tests/test_sphinxext_packagetoctree.py
+++ b/tests/test_sphinxext_packagetoctree.py
@@ -1,0 +1,22 @@
+"""Tests for documenteer.sphinext.packagetoctree (package-toctree and
+module-toctree directives).
+"""
+
+from documenteer.sphinxext.packagetoctree import _filter_index_pages
+
+
+def test_filter_index_pages():
+    """Test _filter_index_pages.
+    """
+    docnames = [
+        'index',
+        'basedir/A/index',
+        'basedir/B/index',
+        'basedir/B/subdir/index'
+        'otherdir/C/index'
+    ]
+    expected = [
+        'basedir/A/index',
+        'basedir/B/index',
+    ]
+    assert set(expected) == set(list(_filter_index_pages(docnames, 'basedir')))


### PR DESCRIPTION
These new directives are primarily for https://github.com/lsst/pipelines_lsst_io to create dynamic tables of contents for packages.

Create a toctree of `modules` with

```rst
.. module-toctree::
```

Create a toctree of `packages` with

```rst
.. package-toctree::
```