### PR TITLE
DM-14095: Add stack-docs and package-docs command line apps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,17 @@ Unreleased
   These create toctrees for modules and packages, respectively, in Stack documentation sites like pipelines.lsst.io.
   With these directives, we don't need to modify the ``index.rst`` file in https://github.com/lsst/pipelines_lsst_io each time new packages are added or removed.
 
+- New ``stack-docs`` command-line app.
+  This replaces ``build-stack-docs``, and now provides a subcommand interface: ``stack-docs build`` and ``stack-docs clean``.
+
+- New ``package-docs`` command-line app.
+  This CLI complements ``stack-docs``, but is intended for single-package documentation.
+  This effectively lets us replace the Sphinx Makefile (including the ``clean`` command).
+  Using a packaged app lets us avoid SIP issues, as well as Makefile drift in individual packages.
+
+- Refactored the Sphinx interface into ``documenteer.sphinxrunner.run_sphinx``.
+  This change lets multiple command-line front-ends to drive Sphinx.
+
 0.2.7 (2018-03-09)
 ------------------
 

--- a/documenteer/sphinxrunner.py
+++ b/documenteer/sphinxrunner.py
@@ -1,0 +1,102 @@
+"""Run Sphinx directly through its Python API.
+"""
+
+__all__ = ('run_sphinx',)
+
+import os
+import logging
+import sys
+
+from sphinx.application import Sphinx
+try:
+    from sphinx.cmd.build import handle_exception
+except ImportError:
+    # Sphinx <1.7
+    from sphinx.cmdline import handle_exception
+from sphinx.util.docutils import docutils_namespace
+
+
+def run_sphinx(root_dir):
+    """Run the Sphinx build process.
+
+    Parameters
+    ----------
+    root_dir : `str`
+        Root directory of the Sphinx project and content source. This directory
+        conatains both the root ``index.rst`` file and the ``conf.py``
+        configuration file.
+
+    Returns
+    -------
+    status : `int`
+        Sphinx status code. ``0`` is expected. Greater than ``0`` indicates
+        an error.
+
+    Notes
+    -----
+    This function implements similar internals to Sphinx's own ``sphinx-build``
+    command. Most configurations are hard-coded to defaults appropriate for
+    building stack documentation, but flexibility can be added later as
+    needs are identified.
+    """
+    logger = logging.getLogger(__name__)
+
+    # This replicates what Sphinx's internal command line hander does
+    # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/cmdline.py
+
+    # configuration
+    root_dir = os.path.abspath(root_dir)
+    srcdir = root_dir  # root directory of Sphinx content
+    confdir = root_dir  # directory where conf.py is located
+    outdir = os.path.join(root_dir, '_build', 'html')
+    doctreedir = os.path.join(root_dir, '_build', 'doctree')
+    builder = 'html'
+    confoverrides = {}
+    status = sys.stdout  # set to None for 'quiet' mode
+    warning = sys.stderr
+    error = sys.stderr
+    freshenv = False  # attempt to re-use existing build artificats
+    warningiserror = False
+    tags = []
+    verbosity = 0
+    jobs = 1  # number of processes
+    force_all = True
+    filenames = []
+
+    logger.debug('Sphinx config: srcdir={0}'.format(srcdir))
+    logger.debug('Sphinx config: confdir={0}'.format(confdir))
+    logger.debug('Sphinx config: outdir={0}'.format(outdir))
+    logger.debug('Sphinx config: doctreedir={0}'.format(doctreedir))
+    logger.debug('Sphinx config: builder={0}'.format(builder))
+    logger.debug('Sphinx config: freshenv={0:b}'.format(freshenv))
+    logger.debug('Sphinx config: warningiserror={0:b}'.format(warningiserror))
+    logger.debug('Sphinx config: verbosity={0:d}'.format(verbosity))
+    logger.debug('Sphinx config: jobs={0:d}'.format(jobs))
+    logger.debug('Sphinx config: force_all={0:b}'.format(force_all))
+
+    app = None
+    try:
+        # NOTE: Sphinx 1.6+ also uses a
+        # sphinx.util.docutils.patch_docutils() context
+        with docutils_namespace():
+            app = Sphinx(
+                srcdir, confdir, outdir, doctreedir, builder,
+                confoverrides, status, warning, freshenv,
+                warningiserror, tags, verbosity, jobs)
+            app.build(force_all, filenames)
+            return app.statuscode
+    except (Exception, KeyboardInterrupt) as exc:
+        args = MockSphinxNamespace(verbosity=verbosity, traceback=True)
+        handle_exception(app, args, exc, error)
+        return 1
+
+
+class MockSphinxNamespace(object):
+    """Mock Namespace object to mock the Sphinx command line arguments.
+
+    This class is needed for sphinx.cmd.build.handle_exception.
+    """
+
+    def __init__(self, verbosity=0, traceback=True):
+        self.verbosity = verbosity
+        self.traceback = traceback

--- a/documenteer/stackdocs/packagecli.py
+++ b/documenteer/stackdocs/packagecli.py
@@ -1,0 +1,95 @@
+"""Implements the ``package-docs`` CLI for single-package documentation builds
+in the LSST Stack.
+"""
+
+__all__ = ('main',)
+
+import logging
+import os
+import shutil
+import sys
+
+import click
+
+from ..sphinxrunner import run_sphinx
+
+
+# Add -h as a help shortcut option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.option(
+    '-d', '--dir', 'root_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True,
+                    resolve_path=True),
+    default='.',
+    help='Root Sphinx doc/ directory'
+)
+@click.option(
+    '-v', '--verbose',
+    is_flag=True,
+    help='Enable verbose output (debug-level logging)'
+)
+@click.version_option()
+@click.pass_context
+def main(ctx, root_dir, verbose):
+    """package-docs is a CLI for building single-package previews of
+    documentation in the LSST Stack.
+    """
+    # Subcommands should use the click.pass_obj decorator to get this
+    # ctx.obj object as the first argument.
+    ctx.obj = {'root_dir': root_dir,
+               'verbose': verbose}
+
+    # Set up application logging. This ensures that only documenteer's
+    # logger is activated. If necessary, we can add other app's loggers too.
+    if verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logger = logging.getLogger('documenteer')
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(log_level)
+
+
+@main.command()
+@click.argument('topic', default=None, required=False, nargs=1)
+@click.pass_context
+def help(ctx, topic, **kw):
+    """Show help for any command.
+    """
+    # The help command implementation is taken from
+    # https://www.burgundywall.com/post/having-click-help-subcommand
+    if topic is None:
+        click.echo(ctx.parent.get_help())
+    else:
+        click.echo(main.commands[topic].get_help(ctx))
+
+
+@main.command()
+@click.pass_context
+def build(ctx):
+    """Build documentation as HTML.
+    """
+    return_code = run_sphinx(ctx.obj['root_dir'])
+    if return_code > 0:
+        sys.exit(return_code)
+
+
+@main.command()
+@click.pass_context
+def clean(ctx):
+    """Clean Sphinx build products.
+    """
+    logger = logging.getLogger(__name__)
+
+    dirnames = ['py-api', '_build']
+    dirnames = [os.path.join(ctx.obj['root_dir'], dirname)
+                for dirname in dirnames]
+    for dirname in dirnames:
+        if os.path.isdir(dirname):
+            shutil.rmtree(dirname)
+            logger.debug('Cleaned up %r', dirname)
+        else:
+            logger.debug('Did not clean up %r (missing)', dirname)

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -4,6 +4,8 @@
 __all__ = ('main',)
 
 import logging
+import os
+import shutil
 import sys
 import click
 
@@ -71,3 +73,21 @@ def build(ctx):
     return_code = build_stack_docs(ctx.obj['root_project_dir'])
     if return_code > 0:
         sys.exit(return_code)
+
+
+@main.command()
+@click.pass_context
+def clean(ctx):
+    """Clean Sphinx build products.
+    """
+    logger = logging.getLogger(__name__)
+
+    dirnames = ['py-api', '_build', 'modules', 'packages']
+    dirnames = [os.path.join(ctx.obj['root_project_dir'], dirname)
+                for dirname in dirnames]
+    for dirname in dirnames:
+        if os.path.isdir(dirname):
+            shutil.rmtree(dirname)
+            logger.debug('Cleaned up %r', dirname)
+        else:
+            logger.debug('Did not clean up %r (missing)', dirname)

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -4,7 +4,10 @@
 __all__ = ('main',)
 
 import logging
+import sys
 import click
+
+from .build import build_stack_docs
 
 
 # Add -h as a help shortcut option
@@ -58,3 +61,13 @@ def help(ctx, topic, **kw):
         click.echo(ctx.parent.get_help())
     else:
         click.echo(main.commands[topic].get_help(ctx))
+
+
+@main.command()
+@click.pass_context
+def build(ctx):
+    """Build documentation as HTML.
+    """
+    return_code = build_stack_docs(ctx.obj['root_project_dir'])
+    if return_code > 0:
+        sys.exit(return_code)

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -24,6 +24,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     is_flag=True,
     help='Enable verbose output (debug-level logging)'
 )
+@click.version_option()
 @click.pass_context
 def main(ctx, root_project_dir, verbose):
     """stack-docs is a CLI for building LSST Stack documentation, such as

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -1,0 +1,42 @@
+"""Implements the ``stack-docs`` CLI for stack documentation builds.
+"""
+
+__all__ = ('main',)
+
+import click
+
+
+# Add -h as a help shortcut option
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.option(
+    '-d', '--dir', 'root_project_dir',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True,
+                    resolve_path=True),
+    default='.',
+    help='Root Sphinx project directory'
+)
+@click.pass_context
+def main(ctx, root_project_dir):
+    """stack-docs is a CLI for building LSST Stack documentation, such as
+    pipelines.lsst.io.
+    """
+    # Subcommands should use the click.pass_obj decorator to get this
+    # ctx.obj object as the first argument.
+    ctx.obj = {'root_project_dir': root_project_dir}
+
+
+@main.command()
+@click.argument('topic', default=None, required=False, nargs=1)
+@click.pass_context
+def help(ctx, topic, **kw):
+    """Show help for any command.
+    """
+    # The help command implementation is taken from
+    # https://www.burgundywall.com/post/having-click-help-subcommand
+    if topic is None:
+        click.echo(ctx.parent.get_help())
+    else:
+        click.echo(main.commands[topic].get_help(ctx))

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -3,6 +3,7 @@
 
 __all__ = ('main',)
 
+import logging
 import click
 
 
@@ -18,14 +19,30 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     default='.',
     help='Root Sphinx project directory'
 )
+@click.option(
+    '-v', '--verbose',
+    is_flag=True,
+    help='Enable verbose output (debug-level logging)'
+)
 @click.pass_context
-def main(ctx, root_project_dir):
+def main(ctx, root_project_dir, verbose):
     """stack-docs is a CLI for building LSST Stack documentation, such as
     pipelines.lsst.io.
     """
     # Subcommands should use the click.pass_obj decorator to get this
     # ctx.obj object as the first argument.
-    ctx.obj = {'root_project_dir': root_project_dir}
+    ctx.obj = {'root_project_dir': root_project_dir,
+               'verbose': verbose}
+
+    # Set up application logging. This ensures that only documenteer's
+    # logger is activated. If necessary, we can add other app's loggers too.
+    if verbose:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+    logger = logging.getLogger('documenteer')
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(log_level)
 
 
 @main.command()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ install_requires = [
     'PyYAML',
     'sphinx-prompt',
     'GitPython',
-    'requests'
+    'requests',
+    'click>=6.7,<7.0'
 ]
 
 # Project-specific dependencies
@@ -92,6 +93,7 @@ setup(
     extras_require=extras_require,
     entry_points={
         'console_scripts': [
+            'stack-docs = documenteer.stackdocs.stackcli:main',
             'build-stack-docs = documenteer.stackdocs.build:run_build_cli',
             'refresh-lsst-bib = documenteer.bin.refreshlsstbib:run'
         ]

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
     entry_points={
         'console_scripts': [
             'stack-docs = documenteer.stackdocs.stackcli:main',
+            'package-docs = documenteer.stackdocs.packagecli:main',
             'build-stack-docs = documenteer.stackdocs.build:run_build_cli',
             'refresh-lsst-bib = documenteer.bin.refreshlsstbib:run'
         ]


### PR DESCRIPTION
- New `stack-docs` command-line app. This replaces `build-stack-docs`, and now provides a subcommand interface: `stack-docs build` and `stack-docs clean`.

- New `package-docs` command-line app. This CLI complements `stack-docs`, but is intended for single-package documentation. This effectively lets us replace the Sphinx Makefile (including the `clean` command). Using a packaged app lets us avoid SIP issues, as well as Makefile drift in individual packages.

- Refactored the Sphinx interface into `documenteer.sphinxrunner.run_sphinx`. This change lets multiple command-line front-ends to drive Sphinx.

Fixes #18