### PR TITLE
Include exclude_patterns in VCS version check

### DIFF
--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -75,6 +75,11 @@ def _build_confs(metadata):
 
     c['copyright'] = metadata['copyright']
 
+    # List of patterns, relative to source directory, that match files and
+    # directories to ignore when looking for source files.
+    c['exclude_patterns'] = metadata.get('exclude_patterns',
+                                         ['_build', 'README.rst'])
+
     # attempt to obtain the version as the Git branch
     try:
         c['version'] = read_git_branch()
@@ -152,10 +157,6 @@ def _build_confs(metadata):
 
     # The master toctree document.
     c['master_doc'] = 'index'
-
-    # List of patterns, relative to source directory, that match files and
-    # directories to ignore when looking for source files.
-    c['exclude_patterns'] = ['_build', 'README.rst']
 
     # If true, `todo` and `todoList` produce output, else they produce nothing.
     c['todo_include_todos'] = True

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -120,7 +120,8 @@ def _build_confs(metadata):
     else:
         # obain date from git commit at most recent content commit since HEAD
         try:
-            date = get_project_content_commit_date()
+            date = get_project_content_commit_date(
+                exclusions=c['exclude_patterns'])
         except Exception as e:
             print('Caught exception: {}'.format(e))
             print('Cannot get project content git commit date.')

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -180,7 +180,7 @@ def get_project_content_commit_date(root_dir='.', exclusions=None):
             commit_datetimes.append(datetime)
         except IOError:
             logger.warning(
-                'Count not get commit for {}, skipping'.format(filepath))
+                'Could not get commit for {}, skipping'.format(filepath))
 
     if not commit_datetimes:
         raise RuntimeError('No content commits could be found')

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -6,6 +6,7 @@ import re
 
 import git
 
+from sphinx.util.matching import Matcher
 
 TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)$')
 
@@ -115,7 +116,7 @@ def get_filepaths_with_extension(extname, root_dir='.'):
     return selected_filenames
 
 
-def get_project_content_commit_date(root_dir='.'):
+def get_project_content_commit_date(root_dir='.', exclusions=None):
     """Get the datetime for the most recent commit to a project that
     affected Sphinx content.
 
@@ -159,10 +160,12 @@ def get_project_content_commit_date(root_dir='.'):
             root_dir=root_dir)
 
     # Known files that should be excluded; lower case for comparison
-    exclusions = ('readme.rst', 'license.rst')
+    exclude = Matcher(exclusions if exclusions
+                      else ['readme.rst', 'license.rst'])
+
     # filter out excluded files
     content_paths = [p for p in content_paths
-                     if p.lower() not in exclusions]
+                     if not (exclude(p) or exclude(p.split(os.path.sep)[0]))]
     logger.debug('Found content paths: {}'.format(', '.join(content_paths)))
 
     if not content_paths:


### PR DESCRIPTION
I had a bunch of other files lying around in my repository, and every time I typed `make` I got a screenfull of warnings about files for which we couldn't get a commit, which was annoying.

This is a quick & dirty attempt to fix the issue. I am not deeply enough immersed in Documenteer culture to know whether this is appropriate, but it seems to work for me...