### PR TITLE
DM-14777: Add remote-code-block directive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Unreleased
 - Recognize a new field in the ``metadata.yaml`` files of Sphinx technotes called ``exclude_patterns``.
   This is an array of file or directory paths that will be ignored by Sphinx during its build, as well as extensions like our ``get_project_content_commit_date`` for looking up commit date of content files.
 
+- Updated to Sphinx >1.7.0, <0.2.0.
+
 - Updated to lsst-sphinx-bootstrap-theme 0.3.x for pipelines docs.
 
 - Switched to ``setuptools_scm`` for managing version strings.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,13 @@ Change Log
 Unreleased
 ----------
 
-- Add ``module-toctree`` and ``package-toctree`` directives.
+- New ``remote-code-block``, which works like the ``literalinclude`` directive, but allows you to include content from a URL over the web.
+  You can use this directive after adding ``documenteer.sphinxext`` to the extensions list in a project's ``conf.py``.
+
+- New ``module-toctree`` and ``package-toctree`` directives.
   These create toctrees for modules and packages, respectively, in Stack documentation sites like pipelines.lsst.io.
   With these directives, we don't need to modify the ``index.rst`` file in https://github.com/lsst/pipelines_lsst_io each time new packages are added or removed.
+  You can use this directive after adding ``documenteer.sphinxext`` to the extensions list in a project's ``conf.py``.
 
 - New ``stack-docs`` command-line app.
   This replaces ``build-stack-docs``, and now provides a subcommand interface: ``stack-docs build`` and ``stack-docs clean``.

--- a/documenteer/requestsutils.py
+++ b/documenteer/requestsutils.py
@@ -1,0 +1,52 @@
+"""Utilities for working with requests.
+"""
+
+__all__ = ('requests_retry_session',)
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+
+def requests_retry_session(
+        retries=3,
+        backoff_factor=0.3,
+        status_forcelist=(500, 502, 504),
+        session=None):
+    """Create a requests session that handles errors by retrying.
+
+    Parameters
+    ----------
+    retries : `int`, optional
+        Number of retries to attempt.
+    backoff_factor : `float`, optional
+        Backoff factor.
+    status_forcelist : sequence of `str`, optional
+        Status codes that must be retried.
+    session : `requests.Session`
+        An existing requests session to configure.
+
+    Returns
+    -------
+    session : `requests.Session`
+        Requests session that can take ``get`` and ``post`` methods, for
+        example.
+
+    Notes
+    -----
+    This function is based on
+    https://www.peterbe.com/plog/best-practice-with-retries-with-requests
+    by Peter Bengtsson.
+    """
+    session = session or requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session

--- a/documenteer/sphinxext/__init__.py
+++ b/documenteer/sphinxext/__init__.py
@@ -14,7 +14,12 @@ automatically enabled. They should be specified individually. They are:
 - ``documenteer.sphinxext.bibtex``
 """
 
-from . import jira, lsstdocushare, mockcoderefs, packagetoctree
+__all__ = ('setup',)
+
+from pkg_resources import get_distribution, DistributionNotFound
+
+from . import (jira, lsstdocushare, mockcoderefs, packagetoctree,
+               remotecodeblock)
 
 
 def setup(app):
@@ -24,3 +29,13 @@ def setup(app):
     lsstdocushare.setup(app)
     mockcoderefs.setup(app)
     packagetoctree.setup(app)
+    remotecodeblock.setup(app)
+
+    try:
+        __version__ = get_distribution('documenteer').version
+    except DistributionNotFound:
+        # package is not installed
+        __version__ = 'unknown'
+    return {'version': __version__,
+            'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/documenteer/sphinxext/remotecodeblock.py
+++ b/documenteer/sphinxext/remotecodeblock.py
@@ -1,0 +1,154 @@
+"""``remote-code-block`` directive that works like ``literalinclude``, but
+supports getting content over https.
+"""
+
+__all__ = ('setup',)
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from pkg_resources import get_distribution, DistributionNotFound
+from sphinx.directives.code import (LiteralIncludeReader,
+                                    container_wrapper)
+from sphinx.util import parselinenos
+from sphinx.util import logging
+from sphinx.util.nodes import set_source_info
+
+from ..requestsutils import requests_retry_session
+
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteCodeBlock(Directive):
+    """Directive that works like ``literalinclude`` to show a code block, but
+    supports getting content over https.
+
+    Notes
+    -----
+    This code is based on Sphinx's LiteralInclude. Copyright 2007-2018 by the
+    Sphinx team.
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    option_spec = {
+        'dedent': int,
+        'linenos': directives.flag,
+        'lineno-start': int,
+        'lineno-match': directives.flag,
+        'tab-width': int,
+        'language': directives.unchanged_required,
+        'encoding': directives.encoding,
+        'pyobject': directives.unchanged_required,
+        'lines': directives.unchanged_required,
+        'start-after': directives.unchanged_required,
+        'end-before': directives.unchanged_required,
+        'start-at': directives.unchanged_required,
+        'end-at': directives.unchanged_required,
+        'prepend': directives.unchanged_required,
+        'append': directives.unchanged_required,
+        'emphasize-lines': directives.unchanged_required,
+        'caption': directives.unchanged,
+        'class': directives.class_option,
+        'name': directives.unchanged,
+        'diff': directives.unchanged_required,
+    }
+
+    @property
+    def env(self):
+        """Reference to the ``.BuildEnvironment`` object.
+
+        FIXME: this can be removed with Sphinx 1.8.0.
+        """
+        return self.state.document.settings.env
+
+    @property
+    def config(self):
+        """Reference to the `Config`` object.
+
+        FIXME: this can be removed with Sphinx 1.8.0.
+        """
+        return self.env.config
+
+    def run(self):
+        """Run the ``remote-code-block`` directive.
+        """
+        document = self.state.document
+        if not document.settings.file_insertion_enabled:
+            return [document.reporter.warning('File insertion disabled',
+                                              line=self.lineno)]
+
+        try:
+            location = self.state_machine.get_source_and_line(self.lineno)
+
+            # Customized for RemoteCodeBlock
+            url = self.arguments[0]
+            reader = RemoteCodeBlockReader(url, self.options, self.config)
+            text, lines = reader.read(location=location)
+
+            retnode = nodes.literal_block(text, text)
+            set_source_info(self, retnode)
+            if self.options.get('diff'):  # if diff is set, set udiff
+                retnode['language'] = 'udiff'
+            elif 'language' in self.options:
+                retnode['language'] = self.options['language']
+            retnode['linenos'] = ('linenos' in self.options or
+                                  'lineno-start' in self.options or
+                                  'lineno-match' in self.options)
+            retnode['classes'] += self.options.get('class', [])
+            extra_args = retnode['highlight_args'] = {}
+            if 'emphasize-lines' in self.options:
+                hl_lines = parselinenos(self.options['emphasize-lines'], lines)
+                if any(i >= lines for i in hl_lines):
+                    logger.warning(
+                        'line number spec is out of range(1-%d): %r' %
+                        (lines, self.options['emphasize-lines']),
+                        location=location)
+                extra_args['hl_lines'] = [x + 1 for x in hl_lines if x < lines]
+            extra_args['linenostart'] = reader.lineno_start
+
+            if 'caption' in self.options:
+                caption = self.options['caption'] or self.arguments[0]
+                retnode = container_wrapper(self, retnode, caption)
+
+            # retnode will be note_implicit_target that is linked from caption
+            # and numref.  when options['name'] is provided, it should be
+            # primary ID.
+            self.add_name(retnode)
+
+            return [retnode]
+
+        except Exception as exc:
+            return [document.reporter.warning(str(exc), line=self.lineno)]
+
+
+class RemoteCodeBlockReader(LiteralIncludeReader):
+    """Reader for content used by `RemoteCodeBlock`.
+    """
+
+    def read_file(self, url, location=None):
+        """Read content from the web by overriding
+        `LiteralIncludeReader.read_file`.
+        """
+        response = requests_retry_session().get(url, timeout=10.0)
+        response.raise_for_status()
+        text = response.text
+        if 'tab-width' in self.options:
+            text = text.expandtabs(self.options['tab-width'])
+
+        return text.splitlines(True)
+
+
+def setup(app):
+    app.add_directive('remote-code-block', RemoteCodeBlock)
+
+    try:
+        __version__ = get_distribution('documenteer').version
+    except DistributionNotFound:
+        # package is not installed
+        __version__ = 'unknown'
+    return {'version': __version__,
+            'parallel_read_safe': True,
+            'parallel_write_safe': True}

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'docutils==0.13.1',  # currently pinned in conjunction with Sphinx
-    'Sphinx>=1.5.0,<1.6.0',
+    'Sphinx>=1.7.0,<2.0.0',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',


### PR DESCRIPTION
The `remote-code-block` directive is implemented as a subclass of `literalinclude`. The only difference is that the file reader code is swapped for requests.get so that it fetches code files over the web.

This code uses the requests_retry_session session builder to ensure that GETs are retried.

Also includes `requests_retry_session` from https://www.peterbe.com/plog/best-practice-with-retries-with-requests to robustly retry GETs that fail due to network errors.