### PR TITLE
DM-14805: allow stack-docs and package-docs CLI to discover conf.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,13 @@ Unreleased
 
 - New ``stack-docs`` command-line app.
   This replaces ``build-stack-docs``, and now provides a subcommand interface: ``stack-docs build`` and ``stack-docs clean``.
+  This CLI is nice to use since it'll discover the root conf.py as long as you're in the root documentation repository.
 
 - New ``package-docs`` command-line app.
   This CLI complements ``stack-docs``, but is intended for single-package documentation.
   This effectively lets us replace the Sphinx Makefile (including the ``clean`` command).
   Using a packaged app lets us avoid SIP issues, as well as Makefile drift in individual packages.
+  This CLI is nice to use since it'll discover the doc/ directory of a package as long as you're in the package's root directory, the doc/ directory, or a subdirectory of doc/.
 
 - Refactored the Sphinx interface into ``documenteer.sphinxrunner.run_sphinx``.
   This change lets multiple command-line front-ends to drive Sphinx.

--- a/documenteer/stackdocs/packagecli.py
+++ b/documenteer/stackdocs/packagecli.py
@@ -12,6 +12,7 @@ import sys
 import click
 
 from ..sphinxrunner import run_sphinx
+from .rootdiscovery import discover_package_doc_dir
 
 
 # Add -h as a help shortcut option
@@ -24,7 +25,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     type=click.Path(exists=True, file_okay=False, dir_okay=True,
                     resolve_path=True),
     default='.',
-    help='Root Sphinx doc/ directory'
+    help="Root Sphinx doc/ directory. You don't need to set this argument "
+         "explicitly as long as the current working directory is either the "
+         "root of the package, the doc/ directory, or a subdirectory of doc/."
 )
 @click.option(
     '-v', '--verbose',
@@ -37,6 +40,8 @@ def main(ctx, root_dir, verbose):
     """package-docs is a CLI for building single-package previews of
     documentation in the LSST Stack.
     """
+    root_dir = discover_package_doc_dir(root_dir)
+
     # Subcommands should use the click.pass_obj decorator to get this
     # ctx.obj object as the first argument.
     ctx.obj = {'root_dir': root_dir,

--- a/documenteer/stackdocs/rootdiscovery.py
+++ b/documenteer/stackdocs/rootdiscovery.py
@@ -1,0 +1,85 @@
+"""Utilities for detecting the root directory of Sphinx documentation.
+"""
+
+__all__ = ('discover_package_doc_dir',)
+
+import pathlib
+
+
+def discover_package_doc_dir(initial_dir):
+    """Discover the ``doc/`` dir of a package given an initial directory.
+
+    Parameters
+    ----------
+    initial_dir : `str`
+        The inititial directory to search from. In practice, this is often the
+        directory that the user is running the package-docs CLI from. This
+        directory needs to be somewhere inside the package's repository.
+
+    Returns
+    -------
+    root_dir : `str`
+        The root documentation directory (``doc/``), containing ``conf.py``.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if a ``conf.py`` file is not found in the initial directory,
+        or any parents, or in a ```doc/`` subdirectory.
+    """
+    # Create an absolute Path to work with
+    initial_dir = pathlib.Path(initial_dir).resolve()
+
+    # Check if this is the doc/ dir already with a conf.py
+    if _has_conf_py(initial_dir):
+        return str(initial_dir)
+
+    # Search for a doc/ directory in cwd (this covers the case of running
+    # the CLI from the root of a repository).
+    test_dir = initial_dir / 'doc'
+    if test_dir.exists() and test_dir.is_dir():
+        if _has_conf_py(test_dir):
+            return str(test_dir)
+
+    # Search upwards until a conf.py is found
+    try:
+        return str(_search_parents(initial_dir))
+    except FileNotFoundError:
+        raise
+
+
+def _has_conf_py(root_dir):
+    if (root_dir / 'conf.py').exists():
+        return True
+    else:
+        return False
+
+
+def _search_parents(initial_dir):
+    """Search the initial and parent directories for a ``conf.py`` Sphinx
+    configuration file that represents the root of a Sphinx project.
+
+    Returns
+    -------
+    root_dir : `pathlib.Path`
+        Directory path containing a ``conf.py`` file.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if a ``conf.py`` file is not found in the initial directory
+        or any parents.
+    """
+    root_paths = ('.', '/')
+    parent = pathlib.Path(initial_dir)
+    while True:
+        if _has_conf_py(parent):
+            return parent
+        if str(parent) in root_paths:
+            break
+        parent = parent.parent
+    msg = (
+        "Cannot detect a conf.py Sphinx configuration file from {!s}. "
+        "Are you inside a Sphinx documenation repository?"
+    ).format(initial_dir)
+    raise FileNotFoundError(msg)

--- a/documenteer/stackdocs/rootdiscovery.py
+++ b/documenteer/stackdocs/rootdiscovery.py
@@ -1,7 +1,7 @@
 """Utilities for detecting the root directory of Sphinx documentation.
 """
 
-__all__ = ('discover_package_doc_dir',)
+__all__ = ('discover_package_doc_dir', 'discover_conf_py_directory')
 
 import pathlib
 
@@ -40,6 +40,39 @@ def discover_package_doc_dir(initial_dir):
     if test_dir.exists() and test_dir.is_dir():
         if _has_conf_py(test_dir):
             return str(test_dir)
+
+    # Search upwards until a conf.py is found
+    try:
+        return str(_search_parents(initial_dir))
+    except FileNotFoundError:
+        raise
+
+
+def discover_conf_py_directory(initial_dir):
+    """Discover the directory containing the conf.py file.
+
+    This function is useful for building stack docs since it will look in
+    the current working directory and all parents.
+
+    Parameters
+    ----------
+    initial_dir : `str`
+        The inititial directory to search from. In practice, this is often the
+        directory that the user is running the stack-docs CLI from.
+
+    Returns
+    -------
+    root_dir : `str`
+        The root documentation directory containing ``conf.py``.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if a ``conf.py`` file is not found in the initial directory,
+        or any parents.
+    """
+    # Create an absolute Path to work with
+    initial_dir = pathlib.Path(initial_dir).resolve()
 
     # Search upwards until a conf.py is found
     try:

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -10,6 +10,7 @@ import sys
 import click
 
 from .build import build_stack_docs
+from .rootdiscovery import discover_conf_py_directory
 
 
 # Add -h as a help shortcut option
@@ -22,7 +23,10 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
     type=click.Path(exists=True, file_okay=False, dir_okay=True,
                     resolve_path=True),
     default='.',
-    help='Root Sphinx project directory'
+    help="Root Sphinx project directory. You don't need to set this argument "
+         "explicitly as long as the current working directory is the "
+         "main documentation repo (pipelines_lsst_io for example) or a "
+         "subdirectory of it."
 )
 @click.option(
     '-v', '--verbose',
@@ -35,6 +39,8 @@ def main(ctx, root_project_dir, verbose):
     """stack-docs is a CLI for building LSST Stack documentation, such as
     pipelines.lsst.io.
     """
+    root_project_dir = discover_conf_py_directory(root_project_dir)
+
     # Subcommands should use the click.pass_obj decorator to get this
     # ctx.obj object as the first argument.
     ctx.obj = {'root_project_dir': root_project_dir,

--- a/tests/test_stackdocs_rootdiscovery.py
+++ b/tests/test_stackdocs_rootdiscovery.py
@@ -27,7 +27,7 @@ def test_search_parents_found():
     """
     with tempfile.TemporaryDirectory() as tempdir:
         root_dir = pathlib.Path(tempdir)
-        os.makedirs(root_dir / 'a' / 'b')
+        os.makedirs(str(root_dir / 'a' / 'b'))
         _install_conf_py(root_dir)
         assert _search_parents(root_dir / 'a' / 'b') == root_dir
 
@@ -37,7 +37,7 @@ def test_search_parents_not_found():
     """
     with tempfile.TemporaryDirectory() as tempdir:
         root_dir = pathlib.Path(tempdir)
-        os.makedirs(root_dir / 'a' / 'b')
+        os.makedirs(str(root_dir / 'a' / 'b'))
         with pytest.raises(FileNotFoundError):
             _search_parents(root_dir / 'a' / 'b')
 
@@ -67,7 +67,7 @@ def test_discover_package_doc_dir_search_parents():
     with tempfile.TemporaryDirectory() as tempdir:
         root_dir = pathlib.Path(tempdir)
         _install_conf_py(root_dir)
-        os.makedirs(root_dir / 'a' / 'b')
+        os.makedirs(str(root_dir / 'a' / 'b'))
         expected = pathlib.Path(tempdir).resolve()
         assert discover_package_doc_dir(root_dir / 'a' / 'b') == str(expected)
 
@@ -78,7 +78,7 @@ def test_discover_package_doc_dir_toplevel_doc():
     """
     with tempfile.TemporaryDirectory() as tempdir:
         root_dir = pathlib.Path(tempdir)
-        os.makedirs(root_dir / 'doc')
+        os.makedirs(str(root_dir / 'doc'))
         _install_conf_py(root_dir / 'doc')
         expected = pathlib.Path(tempdir).resolve() / 'doc'
         assert discover_package_doc_dir(tempdir) == str(expected)
@@ -109,12 +109,12 @@ def test_discover_conf_py_directory_search_parents():
     with tempfile.TemporaryDirectory() as tempdir:
         root_dir = pathlib.Path(tempdir)
         _install_conf_py(root_dir)
-        os.makedirs(root_dir / 'a' / 'b')
+        os.makedirs(str(root_dir / 'a' / 'b'))
         expected = pathlib.Path(tempdir).resolve()
         assert discover_conf_py_directory(root_dir / 'a' / 'b') \
             == str(expected)
 
 
 def _install_conf_py(directory):
-    with open(directory / 'conf.py', 'w') as f:
+    with open(str(directory / 'conf.py'), 'w') as f:
         f.write('# test conf.py')

--- a/tests/test_stackdocs_rootdiscovery.py
+++ b/tests/test_stackdocs_rootdiscovery.py
@@ -8,7 +8,8 @@ import tempfile
 import pytest
 
 from documenteer.stackdocs.rootdiscovery import (
-    _has_conf_py, _search_parents, discover_package_doc_dir)
+    _has_conf_py, _search_parents, discover_package_doc_dir,
+    discover_conf_py_directory)
 
 
 def test_has_conf_py():
@@ -81,6 +82,37 @@ def test_discover_package_doc_dir_toplevel_doc():
         _install_conf_py(root_dir / 'doc')
         expected = pathlib.Path(tempdir).resolve() / 'doc'
         assert discover_package_doc_dir(tempdir) == str(expected)
+
+
+def test_discover_conf_py_directory():
+    """Test discover_conf_py_directory when a conf.py exists in the initial
+    directory.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        _install_conf_py(root_dir)
+        expected = pathlib.Path(tempdir).resolve()
+        assert discover_conf_py_directory(tempdir) == str(expected)
+
+
+def test_discover_conf_py_directory_not_found():
+    """Test discover_conf_py_directory when a conf.py does not exist.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        with pytest.raises(FileNotFoundError):
+            discover_conf_py_directory(tempdir)
+
+
+def test_discover_conf_py_directory_search_parents():
+    """Test discover_conf_py_directory when conf.py is in a parent directory.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        _install_conf_py(root_dir)
+        os.makedirs(root_dir / 'a' / 'b')
+        expected = pathlib.Path(tempdir).resolve()
+        assert discover_conf_py_directory(root_dir / 'a' / 'b') \
+            == str(expected)
 
 
 def _install_conf_py(directory):

--- a/tests/test_stackdocs_rootdiscovery.py
+++ b/tests/test_stackdocs_rootdiscovery.py
@@ -1,0 +1,88 @@
+"""Tests for documenteer.stackdocs.rootdiscovery.
+"""
+
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+from documenteer.stackdocs.rootdiscovery import (
+    _has_conf_py, _search_parents, discover_package_doc_dir)
+
+
+def test_has_conf_py():
+    """Test conf.py detection in _has_conf.py.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        initial_dir = pathlib.Path(tempdir)
+        assert _has_conf_py(initial_dir) is False
+        _install_conf_py(initial_dir)
+        assert _has_conf_py(initial_dir) is True
+
+
+def test_search_parents_found():
+    """Test _search_parents where a conf.py can be found.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        os.makedirs(root_dir / 'a' / 'b')
+        _install_conf_py(root_dir)
+        assert _search_parents(root_dir / 'a' / 'b') == root_dir
+
+
+def test_search_parents_not_found():
+    """Test _search_parents where a conf.py **cannot** be found.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        os.makedirs(root_dir / 'a' / 'b')
+        with pytest.raises(FileNotFoundError):
+            _search_parents(root_dir / 'a' / 'b')
+
+
+def test_discover_package_doc_dir():
+    """Test discover_package_doc_dir when a conf.py exists in the initial
+    directory.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        _install_conf_py(root_dir)
+        expected = pathlib.Path(tempdir).resolve()
+        assert discover_package_doc_dir(tempdir) == str(expected)
+
+
+def test_discover_package_doc_dir_not_found():
+    """Test discover_package_doc_dir when a conf.py does not exist.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        with pytest.raises(FileNotFoundError):
+            discover_package_doc_dir(tempdir)
+
+
+def test_discover_package_doc_dir_search_parents():
+    """Test discover_package_doc_dir when conf.py is in a parent directory.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        _install_conf_py(root_dir)
+        os.makedirs(root_dir / 'a' / 'b')
+        expected = pathlib.Path(tempdir).resolve()
+        assert discover_package_doc_dir(root_dir / 'a' / 'b') == str(expected)
+
+
+def test_discover_package_doc_dir_toplevel_doc():
+    """Test discover_package_doc_dir when a doc/ dir exists in the current
+    working directory.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root_dir = pathlib.Path(tempdir)
+        os.makedirs(root_dir / 'doc')
+        _install_conf_py(root_dir / 'doc')
+        expected = pathlib.Path(tempdir).resolve() / 'doc'
+        assert discover_package_doc_dir(tempdir) == str(expected)
+
+
+def _install_conf_py(directory):
+    with open(directory / 'conf.py', 'w') as f:
+        f.write('# test conf.py')


### PR DESCRIPTION
Users will need to set the --dir option of stack-docs and package-docs CLIs less often with this PR.

For stack-docs, as long as the CWD is `pipelines_lsst_io`, or a subdirectory of it, the CLI should find the conf.py file.

For package-docs the doc/conf.py file is discovered as long as:

- the package's root directory
- the doc/ directory
- a subdirectory of doc/

Fixes #28 