### PR TITLE
DM-15006: Make _static optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Unreleased
   - Removed the viewcode extension since that won't scale well with the LSST codebase.
     Ultimately we want to link to source on GitHub.
 
+  - ``_static/`` directories are not needed and won't produce warnings if not present in a package.
+
   - Other internal cleanups for ``documenteer.sphinxconf.stackconf``.
 
 - Recognize a new field in the ``metadata.yaml`` files of Sphinx technotes called ``exclude_patterns``.

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -10,6 +10,7 @@ see licenses/astropy-helpers.txt
 __all__ = ('build_package_configs', 'build_pipelines_lsst_io_configs')
 
 import datetime
+import os
 import sys
 import warnings
 
@@ -96,7 +97,12 @@ def _insert_html_configs(c, *, project_name, short_project_name):
     # here, relative to this directory. They are copied after the builtin
     # static files, so a file named "default.css" will overwrite the builtin
     # "default.css".
-    c['html_static_path'] = ['_static']
+    if os.path.isdir('_static'):
+        c['html_static_path'] = ['_static']
+    else:
+        # If a project does not have a _static/ directory, don't list it
+        # so that there isn't a warning.
+        c['html_static_path'] = []
 
     # Add any extra paths that contain custom files (such as robots.txt or
     # .htaccess) here, relative to this directory. These files are copied

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -2,6 +2,7 @@
 """
 
 import datetime
+import os
 import yaml
 
 import lsst_dd_rtd_theme
@@ -208,7 +209,12 @@ def _build_confs(metadata):
     # here, relative to this directory. They are copied after the builtin
     # static files, so a file named "default.css" will overwrite the builtin
     # "default.css".
-    c['html_static_path'] = ['_static']
+    if os.path.isdir('_static'):
+        c['html_static_path'] = ['_static']
+    else:
+        # If a project does not have a _static/ directory, don't list it
+        # so that there isn't a warning.
+        c['html_static_path'] = []
 
     # Add any extra paths that contain custom files (such as robots.txt or
     # .htaccess) here, relative to this directory. These files are copied

--- a/documenteer/stackdocs/build.py
+++ b/documenteer/stackdocs/build.py
@@ -197,7 +197,8 @@ def find_package_docs(package_dir):
 
         - ``static_doc_dirs`` (`dict`). Keys are directory names relative to
           the ``_static`` directory. Values are absolute directory paths to
-          the static documentation directory in the package.
+          the static documentation directory in the package. If there
+          isn't a declared ``_static`` directory, this dictionary is empty.
 
     Raises
     ------
@@ -213,11 +214,11 @@ def find_package_docs(package_dir):
     There are three types of documentation directories:
 
     1. Package doc directories contain documentation for the EUPS package
-       aspect.
+       aspect. This is optional.
     2. Module doc directories contain documentation for a Python package
-       aspect.
+       aspect. These are optional.
     3. Static doc directories are root directories inside the package's
-       ``doc/_static/`` directory.
+       ``doc/_static/`` directory. These are optional.
 
     These are declared in a package's ``doc/manifest.yaml`` file. For example:
 


### PR DESCRIPTION
If a stack package or technote doesn't have a `_static` directory, it won't be added to the `html_static_path` Sphinx configuration (via `documenteer.sphinxconf`) and thus won't generate a warning at build time.