### PR TITLE
DM-15007: Add -s/--skip options to stack-docs app

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
   These create toctrees for modules and packages, respectively, in Stack documentation sites like pipelines.lsst.io.
   With these directives, we don't need to modify the ``index.rst`` file in https://github.com/lsst/pipelines_lsst_io each time new packages are added or removed.
   You can use this directive after adding ``documenteer.sphinxext`` to the extensions list in a project's ``conf.py``.
+  These directives include ``skip`` options for skipping certain packages and modules.
 
 - New ``stack-docs`` command-line app.
   This replaces ``build-stack-docs``, and now provides a subcommand interface: ``stack-docs build`` and ``stack-docs clean``.

--- a/documenteer/stackdocs/stackcli.py
+++ b/documenteer/stackdocs/stackcli.py
@@ -72,11 +72,19 @@ def help(ctx, topic, **kw):
 
 
 @main.command()
+@click.option(
+    '-s', '--skip', multiple=True,
+    help='A module (e.g. ``lsst.afw.geom`` or package (``afw``) name to '
+         'exclude from the documentation. Provide multiple -s options to skip '
+         'multiple names.'
+)
 @click.pass_context
-def build(ctx):
+def build(ctx, skip):
     """Build documentation as HTML.
     """
-    return_code = build_stack_docs(ctx.obj['root_project_dir'])
+    return_code = build_stack_docs(
+        ctx.obj['root_project_dir'],
+        skippedNames=skip)
     if return_code > 0:
         sys.exit(return_code)
 


### PR DESCRIPTION
This PR tries to solve the problem of temporarily omitting either modules or packages from being included in pipelines documentation.

The best solution is the -s/--skip option for stack-docs that prevents the named package and/or module documentation directories from being linked into the main documentation repository.

This PR also adds skip options to the `module-toctree` and `package-toctree` directives. This solution isn't fully useful until those directives can also remove those documentation directories from the Sphinx build tree.