### PR TITLE
DM-15013: Add scikit-learn and pandas to stack intersphinx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,7 @@ Unreleased
 
   - ``autoclass_content`` is now ``"class"``, fitting the LSST DM standards for writing class docstrings, and not filling out ``__init__`` docstrings.
 
-  - Removed h5py from intersphinx since it was never needed.
+  - Added ``scikit-learn`` and ``pandas`` to the intersphinx configuration; removed h5py from intersphinx since it was never needed and conflicted with ``daf_butler`` documentation.
 
   - Removed the viewcode extension since that won't scale well with the LSST codebase.
     Ultimately we want to link to source on GitHub.

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -54,7 +54,8 @@ def _insert_intersphinx_mapping(c):
         'numpy': ('https://docs.scipy.org/doc/numpy/', None),
         'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
         'matplotlib': ('https://matplotlib.org/', None),
-        'astropy': ('http://docs.astropy.org/en/stable/', None),
+        'sklearn': ('http://scikit-learn.org/stable/', None),
+        'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
     }
     c['intersphinx_timeout'] = 10.0  # seconds
     c['intersphinx_cache_limit'] = 5  # days


### PR DESCRIPTION
These are python dependencies for the LSST Science PIpelines.