### PR TITLE
DM-15802: Release 0.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.3.0 (2018-09-19)
+------------------
 
 - New ``remote-code-block``, which works like the ``literalinclude`` directive, but allows you to include content from a URL over the web.
   You can use this directive after adding ``documenteer.sphinxext`` to the extensions list in a project's ``conf.py``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,7 +48,8 @@ Unreleased
 - Recognize a new field in the ``metadata.yaml`` files of Sphinx technotes called ``exclude_patterns``.
   This is an array of file or directory paths that will be ignored by Sphinx during its build, as well as extensions like our ``get_project_content_commit_date`` for looking up commit date of content files.
 
-- Updated to Sphinx >1.7.0, <0.2.0.
+- Updated to Sphinx >1.7.0, <1.8.0.
+  Sphinx 1.8.0 is known to be incompatible with ``documenteer.sphinxrunner``.
 
 - Updated to lsst-sphinx-bootstrap-theme 0.3.x for pipelines docs.
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -386,7 +386,10 @@ def build_package_configs(project_name,
 
     # List of patterns, relative to source directory, that match files and
     # directories to ignore when looking for source files.
-    c['exclude_patterns'] = ['_build', 'README.rst']
+    c['exclude_patterns'] = [
+        '_build',
+        'README.rst',
+    ]
 
     # Show rendered todo directives in package docs since they're developer
     # facing.
@@ -502,6 +505,8 @@ def build_pipelines_lsst_io_configs(*, project_name, current_release,
         'ups',
         # Recommended directory for pip installing doc eng Python packages
         '.pyvenv',
+        # GitHub templates
+        '.github',
     ]
 
     # Substitutions available on every page

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'Sphinx>=1.7.0,<2.0.0',
+    'Sphinx>=1.7.0,<1.8.0',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',


### PR DESCRIPTION
- Version 0.3.0 release
- Includes a re-pinning of Sphinx to <1.8.0 to avoid an incompatibility with `documenteer.sphinxrunner`.