### PR TITLE
DM-15777: Directive that summarizes a Task's Python API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Unreleased
   - The ``lsst-task-config-fields``, ``lsst-task-config-subtasks``, and ``lsst-config-fields`` directives automatically generate documentation for configuration fields and subtasks in Tasks.
   - The ``lsst-task-topic`` and ``lsst-config-topic`` directives mark pages that document a given task or configuration class.
   - The ``lsst-task``, ``lsst-config``, and ``lsst-config-field`` roles create references to task topics or configuration fields.
+  - The ``lsst-task-api-summary`` directive autogenerates a summary of the of a task's key APIs.
+    This directive does not replace the autodoc-generated documentation for the task's class, but instead provides an affordance that creates a bridge from the task topic to the API reference topic.
 
 0.3.0 (2018-09-19)
 ------------------

--- a/docs/sphinxext/lssttasks.rst
+++ b/docs/sphinxext/lssttasks.rst
@@ -179,3 +179,20 @@ These roles link to task or config topic pages and to individual configuration f
    **See also:**
 
    The :rst:dir:`lsst-task-config-fields`, :rst:dir:`lsst-task-config-subtasks`, and :rst:dir:`lsst-config-fields` directives create the configuration field documentation that this role references.
+
+Task interface directives
+=========================
+
+.. rst:directive:: .. lsst-task-api-summary:: task_name
+
+   Generate a summary of the task's Python API.
+
+   **Required argument:**
+
+   - Name of the task class.
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-task-api-summary:: lsst.pipe.tasks.assembleCoadd.AssembleCoaddTask

--- a/documenteer/sphinxext/lssttasks/__init__.py
+++ b/documenteer/sphinxext/lssttasks/__init__.py
@@ -14,6 +14,7 @@ from .crossrefs import (
     pending_configfield_xref, task_ref_role, config_ref_role,
     configfield_ref_role, process_pending_task_xref_nodes,
     process_pending_config_xref_nodes, process_pending_configfield_xref_nodes)
+from .pyapisummary import TaskApiDirective
 
 
 def setup(app):
@@ -36,6 +37,9 @@ def setup(app):
     app.add_directive(
         ConfigTopicTargetDirective.directive_name,
         ConfigTopicTargetDirective)
+    app.add_directive(
+        TaskApiDirective.directive_name,
+        TaskApiDirective)
     app.add_node(pending_task_xref)
     app.add_node(pending_config_xref)
     app.add_node(pending_configfield_xref)

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -1,8 +1,53 @@
 """Sphinx extensions for summarizing the Python API for tasks.
 """
 
+__all__ = ('TaskApiDirective',)
+
+
+from docutils.parsers.rst import Directive
+from sphinx.errors import SphinxError
+from sphinx.util.logging import getLogger
 from sphinx.util.inspect import getdoc
 from sphinx.util.docstrings import prepare_docstring
+
+from .taskutils import get_type
+
+
+class TaskApiDirective(Directive):
+    """``lsst-task-api-summary`` directive that renders a summary of a LSST
+    Science Pipelines Task's Python API and links to the regular Python API
+    documentation from ``automodapi``.
+    """
+
+    directive_name = 'lsst-task-api-summary'
+    """Default name of this directive.
+    """
+
+    has_content = False
+
+    required_arguments = 1
+
+    def run(self):
+        """Main entrypoint method.
+
+        Returns
+        -------
+        new_nodes : `list`
+            Nodes to add to the doctree.
+        """
+        logger = getLogger(__name__)
+
+        try:
+            task_class_name = self.arguments[0]
+        except IndexError:
+            raise SphinxError(
+                '{} directive requires a Task class '
+                'name as an argument'.format(self.directive_name))
+
+        logger.debug(
+            '%s running with %r', self.directive_name, task_class_name)
+
+        task_class = get_type(task_class_name)
 
 
 def get_docstring(obj):

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -1,0 +1,48 @@
+"""Sphinx extensions for summarizing the Python API for tasks.
+"""
+
+from sphinx.util.inspect import getdoc
+from sphinx.util.docstrings import prepare_docstring
+
+
+def get_docstring(obj):
+    """Extract the docstring from an object as individual lines.
+
+    Parameters
+    ----------
+    obj : object
+        The Python object (class, function or method) to extract docstrings
+        from.
+
+    Returns
+    -------
+    lines : `list` of `str`
+        Individual docstring lines with common indentation removed, and
+        newline characters stripped.
+    """
+    docstring = getdoc(obj, allow_inherited=True)
+    # ignore is simply the number of initial lines to ignore when determining
+    # the docstring's baseline indent level. We really want "1" here.
+    return prepare_docstring(docstring, ignore=1)
+
+
+def extract_docstring_summary(docstring):
+    """Get the first summary sentence from a docstring.
+
+    Parameters
+    ----------
+    docstring : `list` of `str`
+        Output from `get_docstring`.
+
+    Returns
+    -------
+    summary : `str`
+        The plain-text summary sentence from teh docstring.
+    """
+    summary_lines = []
+    for line in docstring:
+        if line == '':
+            break
+        else:
+            summary_lines.append(line)
+    return ' '.join(summary_lines)

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -52,9 +52,11 @@ class TaskApiDirective(Directive):
 
         task_class = get_type(task_class_name)
 
-        nodes = self._format_summary_node(task_class)
+        new_nodes = []
+        new_nodes.extend(self._format_import_example(task_class))
+        new_nodes.extend(self._format_summary_node(task_class))
 
-        return nodes
+        return new_nodes
 
     def _format_summary_node(self, task_class):
         """Format a section node containg a summary of a Task class's key APIs.
@@ -152,6 +154,29 @@ class TaskApiDirective(Directive):
         _pseudo_parse_arglist(desc_sig_node, arglist)
 
         return desc_sig_node
+
+    def _format_import_example(self, task_class):
+        """Generate nodes that show a code sample demonstrating how to import
+        the task class.
+
+        Parameters
+        ----------
+        task_class : ``lsst.pipe.base.Task``-type
+            The Task class.
+
+        Returns
+        -------
+        nodes : `list` of docutils nodes
+            Docutils nodes showing a class import statement.
+        """
+        code = 'from {0.__module__} import {0.__name__}'.format(task_class)
+
+        # This is a bare-bones version of what Sphinx's code-block directive
+        # does. The 'language' attr triggers the pygments treatment.
+        literal_node = nodes.literal_block(code, code)
+        literal_node['language'] = 'py'
+
+        return [literal_node]
 
 
 def get_docstring(obj):

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -10,7 +10,8 @@ from sphinx.errors import SphinxError
 from sphinx.util.logging import getLogger
 from sphinx.util.inspect import getdoc, Signature
 from sphinx.util.docstrings import prepare_docstring
-from sphinx.addnodes import desc, desc_signature, desc_content, desc_addname
+from sphinx.addnodes import (desc, desc_signature, desc_content, desc_addname,
+                             desc_annotation)
 from sphinx.domains.python import _pseudo_parse_arglist, PyXRefRole
 
 from .taskutils import get_type
@@ -143,6 +144,17 @@ class TaskApiDirective(Directive):
         desc_sig_node['module'] = modulename
         desc_sig_node['class'] = classname
         desc_sig_node['fullname'] = fullname
+
+        # Prefix the API signature with the API type
+        prefix = None
+        if refrole == 'py:class':
+            prefix = 'class'
+        elif refrole == 'py:meth':
+            prefix = 'method'
+        if prefix:
+            desc_sig_node += desc_annotation(prefix, prefix)
+
+        # The API name is linked to the canonical API docs
         name_xref_nodes, _ = xref(
             refrole,
             '~' + fullname,

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -55,6 +55,7 @@ class TaskApiDirective(Directive):
         new_nodes = []
         new_nodes.extend(self._format_import_example(task_class))
         new_nodes.extend(self._format_summary_node(task_class))
+        new_nodes.extend(self._format_api_docs_link_message(task_class))
 
         return new_nodes
 
@@ -177,6 +178,41 @@ class TaskApiDirective(Directive):
         literal_node['language'] = 'py'
 
         return [literal_node]
+
+    def _format_api_docs_link_message(self, task_class):
+        """Format a message referring the reader to the full API docs.
+
+        Parameters
+        ----------
+        task_class : ``lsst.pipe.base.Task``-type
+            The Task class.
+
+        Returns
+        -------
+        nodes : `list` of docutils nodes
+            Docutils nodes showing a link to the full API docs.
+        """
+        fullname = '{0.__module__}.{0.__name__}'.format(task_class)
+
+        p_node = nodes.paragraph()
+
+        _ = 'See the '
+        p_node += nodes.Text(_, _)
+
+        xref = PyXRefRole()
+        xref_nodes, _ = xref(
+            'py:class',
+            '~' + fullname,
+            '~' + fullname,
+            self.lineno,
+            self.state.inliner)
+
+        p_node += xref_nodes
+
+        _ = ' API reference for complete details.'
+        p_node += nodes.Text(_, _)
+
+        return [p_node]
 
 
 def get_docstring(obj):


### PR DESCRIPTION
This PR adds a directive that generates a summary of the Python API for a task class. This is meant to be used in task topic pages to bridge task documentation to the autodoc-generated API reference documentation for the task class.

Usage:

```rst
Python API summary
==================

.. lsst-task-api-summary:: lsst.pipe.tasks.assembleCoadd.AssembleCoaddTask
```