### PR TITLE
DM-15900: WIP SphinxExtension registry of extension members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Unreleased
   - The ``lsst-task``, ``lsst-config``, and ``lsst-config-field`` roles create references to task topics or configuration fields.
   - The ``lsst-task-api-summary`` directive autogenerates a summary of the of a task's key APIs.
     This directive does not replace the autodoc-generated documentation for the task's class, but instead provides an affordance that creates a bridge from the task topic to the API reference topic.
+  - The ``lsst-tasks``, ``lsst-cmdlinetasks``, ``lsst-pipelinetasks``, ``lsst-configurables``, and
+    ``lsst-configs`` directives create listings of topics.
+    These listings not only link to the topic, but also show a summary that's either extracted from the corresponding docstring or set through the ``lsst-task-topic`` or ``lsst-config-topic`` directives.
+    These directives also generate a toctree.
 
 0.3.0 (2018-09-19)
 ------------------

--- a/docs/sphinxext/lssttasks.rst
+++ b/docs/sphinxext/lssttasks.rst
@@ -79,6 +79,8 @@ These directives list configuration fields associated with a task or configurati
    - Use :rst:dir:`lsst-task-config-fields` or :rst:dir:`lsst-task-config-subtasks` to list configuration fields when working within a task topic.
    - :rst:role:`lsst-config-field`: role for cross-referencing individual fields documented with this directive.
 
+.. _lssttasks-topic-markers:
+
 Topic markers
 =============
 
@@ -97,11 +99,20 @@ Use these directives at the top of either a task or standalone config topic page
 
    - Name of the task class.
 
+   **Content:**
+
+   You can optionally add a one or two sentence summary of the task as the directive's content.
+   This summary is used by the :ref:`topic listing directives <lssttasks-topic-listings>`.
+   This content is **optional**.
+   If not set, the summary is set from the task's docstring.
+
    **Example:**
 
    .. code-block:: rst
 
       .. lsst-task-topic:: lsst.pipe.tasks.processCcd.ProcessCcdTask
+
+         Summary of ProcessCcdTask.
 
 .. rst:directive:: .. lsst-config-topic:: config_name
 
@@ -111,11 +122,171 @@ Use these directives at the top of either a task or standalone config topic page
 
    - Name of the config class.
 
+   **Content:**
+
+   You can optionally add a one or two sentence summary of the config as the directive's content.
+   This summary is used by the :ref:`topic listing directives <lssttasks-topic-listings>`.
+   This content is **optional**.
+   If not set, the summary is set from the config's docstring.
+
    **Example:**
 
    .. code-block:: rst
 
       .. lsst-config-topic:: lsst.pipe.tasks.colorterms.Colorterm
+
+         Summary of Colorterm.
+
+.. _lssttasks-topic-listings:
+
+Topic listings
+==============
+
+These directives make listings of topics labeled by :ref:`topic markers <lssttasks-topic-markers>`:
+
+- :rst:dir:`lsst-tasks`
+- :rst:dir:`lsst-cmdlinetasks`
+- :rst:dir:`lsst-pipelinetasks`
+- :rst:dir:`lsst-configurables`
+- :rst:dir:`lsst-configs`
+
+.. rst:directive:: lsst-tasks
+
+   List task topics that are marked with the :rst:dir:`lsst-task-topic` directive.
+   Only ``lsst.pipe.base.Task``-types that are not ``CmdLineTask`` or ``PipelineTask``-types are listed by this directive.
+
+   **Options**
+
+   ``root``
+      The root Python package that tasks must belong to to be including in the listing.
+      For example, ``:root: lsst.pipe.tasks`` means that only tasks in the ``lsst.pipe.tasks`` Python subpackage are included in the listing.
+
+   ``toctree``
+      If set, a :rst:dir:`toctree` is automatically generated for pages that appear in a given directory.
+      For example, if task topics are in a ``tasks/`` subdirectory, set ``:toctree: tasks``.
+      The :rst:dir:`toctree` is hidden.
+
+      If this directive is listing topics that are already included by another :rst:dir:`toctree`, **don't set this option.**
+
+      Note that ``toctree`` doesn't filter tasks using the same critera as the ``root`` option.
+      Generally the directory structure should be set up so that ``toctree`` effectively corresponds to the filtering criteria set by ``root``, though.
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-tasks::
+         :root: lsst.pipe.tasks
+         :toctree: tasks
+
+.. rst:directive:: lsst-cmdlinetasks
+
+   List task topics that are marked with the :rst:dir:`lsst-task-topic` directive that correspond to ``lsst.pipe.base.CmdLineTask``-types.
+
+   **Options**
+
+   ``root``
+      The root Python package that tasks must belong to to be including in the listing.
+      For example, ``:root: lsst.pipe.tasks`` means that only tasks in the ``lsst.pipe.tasks`` Python subpackage are included in the listing.
+
+   ``toctree``
+      If set, a :rst:dir:`toctree` is automatically generated for pages that appear in a given directory.
+      For example, if task topics are in a ``tasks/`` subdirectory, set ``:toctree: tasks``.
+      The :rst:dir:`toctree` is hidden.
+
+      If this directive is listing topics that are already included by another :rst:dir:`toctree`, **don't set this option.**
+
+      Note that ``toctree`` doesn't filter tasks using the same critera as the ``root`` option.
+      Generally the directory structure should be set up so that ``toctree`` effectively corresponds to the filtering criteria set by ``root``, though.
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-cmdlinetasks::
+         :root: lsst.pipe.tasks
+         :toctree: tasks
+
+.. rst:directive:: lsst-pipelinetasks
+
+   List task topics that are marked with the :rst:dir:`lsst-task-topic` directive that correspond to ``lsst.pipe.base.PipelineTask``-types.
+
+   **Options**
+
+   ``root``
+      The root Python package that tasks must belong to to be including in the listing.
+      For example, ``:root: lsst.pipe.tasks`` means that only tasks in the ``lsst.pipe.tasks`` Python subpackage are included in the listing.
+
+   ``toctree``
+      If set, a :rst:dir:`toctree` is automatically generated for pages that appear in a given directory.
+      For example, if task topics are in a ``tasks/`` subdirectory, set ``:toctree: tasks``.
+      The :rst:dir:`toctree` is hidden.
+
+      If this directive is listing topics that are already included by another :rst:dir:`toctree`, **don't set this option.**
+
+      Note that ``toctree`` doesn't filter tasks using the same critera as the ``root`` option.
+      Generally the directory structure should be set up so that ``toctree`` effectively corresponds to the filtering criteria set by ``root``, though.
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-pipelinetasks::
+         :root: lsst.pipe.tasks
+         :toctree: tasks
+
+.. rst:directive:: lsst-configurables
+
+   List "configurable" topics that are marked with the :rst:dir:`lsst-task-topic` directive that correspond to generic configurable types.
+
+   **Options**
+
+   ``root``
+      The root Python package that configurables must belong to to be including in the listing.
+      For example, ``:root: lsst.pipe.tasks`` means that only configurables in the ``lsst.pipe.tasks`` Python subpackage are included in the listing.
+
+   ``toctree``
+      If set, a :rst:dir:`toctree` is automatically generated for pages that appear in a given directory.
+      For example, if configurable topics are in a ``configurables/`` subdirectory, set ``:toctree: configurables``.
+      The :rst:dir:`toctree` is hidden.
+
+      If this directive is listing topics that are already included by another :rst:dir:`toctree`, **don't set this option.**
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-configurables::
+         :root: lsst.pipe.tasks
+         :toctree: configurables
+
+.. rst:directive:: lsst-configurables
+
+   List config topics that are marked with the :rst:dir:`lsst-config-topic` directive that correspond to ``lsst.pex.config.Config``-types.
+
+   **Options**
+
+   ``root``
+      The root Python package that configs must belong to to be including in the listing.
+      For example, ``:root: lsst.pipe.tasks`` means that only configs in the ``lsst.pipe.tasks`` Python subpackage are included in the listing.
+
+   ``toctree``
+      If set, a :rst:dir:`toctree` is automatically generated for pages that appear in a given directory.
+      For example, if configurable topics are in a ``configurables/`` subdirectory, set ``:toctree: configurables``.
+      The :rst:dir:`toctree` is hidden.
+
+      If this directive is listing topics that are already included by another :rst:dir:`toctree`, **don't set this option.**
+
+      Note that ``toctree`` doesn't filter tasks using the same critera as the ``root`` option.
+      Generally the directory structure should be set up so that ``toctree`` effectively corresponds to the filtering criteria set by ``root``, though.
+
+   **Example:**
+
+   .. code-block:: rst
+
+      .. lsst-configs::
+         :root: lsst.pipe.tasks
+         :toctree: configs
 
 Cross-reference roles
 =====================

--- a/documenteer/sphinxext/lssttasks/__init__.py
+++ b/documenteer/sphinxext/lssttasks/__init__.py
@@ -16,6 +16,10 @@ from .crossrefs import (
     configfield_ref_role, process_pending_task_xref_nodes,
     process_pending_config_xref_nodes, process_pending_configfield_xref_nodes)
 from .pyapisummary import TaskApiDirective
+from .topiclists import (
+    TaskListDirective, CmdLineTaskListDirective, PipelineTaskListDirective,
+    ConfigurableListDirective, ConfigListDirective,
+    task_topic_list, process_task_topic_list)
 
 
 def setup(app):
@@ -39,14 +43,31 @@ def setup(app):
         ConfigTopicDirective.directive_name,
         ConfigTopicDirective)
     app.add_directive(
+        TaskListDirective.directive_name,
+        TaskListDirective)
+    app.add_directive(
+        CmdLineTaskListDirective.directive_name,
+        CmdLineTaskListDirective)
+    app.add_directive(
+        PipelineTaskListDirective.directive_name,
+        PipelineTaskListDirective)
+    app.add_directive(
+        ConfigurableListDirective.directive_name,
+        ConfigurableListDirective)
+    app.add_directive(
+        ConfigListDirective.directive_name,
+        ConfigListDirective)
+    app.add_directive(
         TaskApiDirective.directive_name,
         TaskApiDirective)
     app.add_node(pending_task_xref)
     app.add_node(pending_config_xref)
     app.add_node(pending_configfield_xref)
+    app.add_node(task_topic_list)
     app.connect('doctree-resolved', process_pending_task_xref_nodes)
     app.connect('doctree-resolved', process_pending_config_xref_nodes)
     app.connect('doctree-resolved', process_pending_configfield_xref_nodes)
+    app.connect('doctree-resolved', process_task_topic_list)
     app.add_role('lsst-task', task_ref_role)
     app.add_role('lsst-config', config_ref_role)
     app.add_role('lsst-config-field', configfield_ref_role)

--- a/documenteer/sphinxext/lssttasks/__init__.py
+++ b/documenteer/sphinxext/lssttasks/__init__.py
@@ -8,9 +8,10 @@ from pkg_resources import get_distribution, DistributionNotFound
 from .subtasks import SubtasksDirective
 from .taskconfigs import TaskConfigsDirective
 from .standaloneconfigs import StandaloneConfigsDirective
+from .topics import (
+    TaskTopicDirective, ConfigurableTopicDirective, ConfigTopicDirective)
 from .crossrefs import (
-    TaskTopicTargetDirective, ConfigurableTopicTargetDirective,
-    ConfigTopicTargetDirective, pending_task_xref, pending_config_xref,
+    pending_task_xref, pending_config_xref,
     pending_configfield_xref, task_ref_role, config_ref_role,
     configfield_ref_role, process_pending_task_xref_nodes,
     process_pending_config_xref_nodes, process_pending_configfield_xref_nodes)
@@ -30,13 +31,13 @@ def setup(app):
         StandaloneConfigsDirective
     )
     app.add_directive(
-        TaskTopicTargetDirective.directive_name, TaskTopicTargetDirective)
+        TaskTopicDirective.directive_name, TaskTopicDirective)
     app.add_directive(
-        ConfigurableTopicTargetDirective.directive_name,
-        ConfigurableTopicTargetDirective)
+        ConfigurableTopicDirective.directive_name,
+        ConfigurableTopicDirective)
     app.add_directive(
-        ConfigTopicTargetDirective.directive_name,
-        ConfigTopicTargetDirective)
+        ConfigTopicDirective.directive_name,
+        ConfigTopicDirective)
     app.add_directive(
         TaskApiDirective.directive_name,
         TaskApiDirective)

--- a/documenteer/sphinxext/lssttasks/__init__.py
+++ b/documenteer/sphinxext/lssttasks/__init__.py
@@ -5,11 +5,13 @@ __all__ = ('setup',)
 
 from pkg_resources import get_distribution, DistributionNotFound
 
+from ..utils import SphinxExtension
+extension = SphinxExtension()  # noqa: E402
+
 from .subtasks import SubtasksDirective
 from .taskconfigs import TaskConfigsDirective
 from .standaloneconfigs import StandaloneConfigsDirective
-from .topics import (
-    TaskTopicDirective, ConfigurableTopicDirective, ConfigTopicDirective)
+from .topics import *  # noqa: F401, F403
 from .crossrefs import (
     pending_task_xref, pending_config_xref,
     pending_configfield_xref, task_ref_role, config_ref_role,
@@ -23,6 +25,7 @@ from .topiclists import (
 
 
 def setup(app):
+    extension.setup(app)
     app.add_directive(
         SubtasksDirective.directive_name,
         SubtasksDirective)
@@ -34,14 +37,14 @@ def setup(app):
         StandaloneConfigsDirective.directive_name,
         StandaloneConfigsDirective
     )
-    app.add_directive(
-        TaskTopicDirective.directive_name, TaskTopicDirective)
-    app.add_directive(
-        ConfigurableTopicDirective.directive_name,
-        ConfigurableTopicDirective)
-    app.add_directive(
-        ConfigTopicDirective.directive_name,
-        ConfigTopicDirective)
+    # app.add_directive(
+    #     TaskTopicDirective.directive_name, TaskTopicDirective)
+    # app.add_directive(
+    #     ConfigurableTopicDirective.directive_name,
+    #     ConfigurableTopicDirective)
+    # app.add_directive(
+    #     ConfigTopicDirective.directive_name,
+    #     ConfigTopicDirective)
     app.add_directive(
         TaskListDirective.directive_name,
         TaskListDirective)

--- a/documenteer/sphinxext/lssttasks/crossrefs.py
+++ b/documenteer/sphinxext/lssttasks/crossrefs.py
@@ -2,8 +2,6 @@
 """
 
 __all__ = ('format_task_id', 'format_config_id', 'format_configfield_id',
-           'TaskTopicTargetDirective', 'ConfigurableTopicTargetDirective',
-           'ConfigTopicTargetDirective',
            'pending_task_xref', 'task_ref_role', 'config_ref_role',
            'configfield_ref_role',
            'process_pending_task_xref_nodes',
@@ -11,9 +9,7 @@ __all__ = ('format_task_id', 'format_config_id', 'format_configfield_id',
            'process_pending_configfield_xref_nodes')
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
 from sphinx.util.logging import getLogger
-from sphinx.errors import SphinxError
 
 from ..utils import split_role_content
 
@@ -70,158 +66,6 @@ def format_configfield_id(config_class_name, field_name):
     """
     return nodes.make_id(
         'lsst-configfield-{0}-{1}'.format(config_class_name, field_name))
-
-
-class TaskTopicTargetDirective(Directive):
-    """``lsst-tasktopic`` directive that labels a Task's topic page.
-    """
-
-    directive_name = 'lsst-task-topic'
-    """Default name of this directive.
-    """
-
-    has_content = False
-
-    required_arguments = 1
-
-    def run(self):
-        """Main entrypoint method.
-
-        Returns
-        -------
-        new_nodes : `list`
-            Nodes to add to the doctree.
-        """
-        env = self.state.document.settings.env
-        logger = getLogger(__name__)
-
-        try:
-            task_class_name = self.arguments[0]
-        except IndexError:
-            raise SphinxError(
-                '{} directive requires a Task class name as an '
-                'argument'.format(self.directive_name)
-            )
-        logger.debug('%s using Task class %s',
-                     self.directive_name, task_class_name)
-
-        target_node = _create_configurable_reference_node(
-            task_class_name, env, self.lineno, is_task=True)
-
-        return [target_node]
-
-
-class ConfigurableTopicTargetDirective(Directive):
-    """``lsst-configurable-topic`` directive that labels a Configurable's topic
-    page.
-
-    Configurables are essentially generalized tasks. They have a ConfigClass,
-    but don't have run methods.
-    """
-
-    directive_name = 'lsst-configurable-topic'
-    """Default name of this directive.
-    """
-
-    has_content = False
-
-    required_arguments = 1
-
-    def run(self):
-        """Main entrypoint method.
-
-        Returns
-        -------
-        new_nodes : `list`
-            Nodes to add to the doctree.
-        """
-        env = self.state.document.settings.env
-        logger = getLogger(__name__)
-
-        try:
-            configurable_class_name = self.arguments[0]
-        except IndexError:
-            raise SphinxError(
-                '{} directive requires a Configurable class name as an '
-                'argument'.format(self.directive_name)
-            )
-        logger.debug('%s using Configurable class %s',
-                     self.directive_name, configurable_class_name)
-
-        target_node = _create_configurable_reference_node(
-            configurable_class_name, env, self.lineno, is_task=False)
-
-        return [target_node]
-
-
-def _create_configurable_reference_node(configurable_class_name, env, lineno,
-                                        is_task=True):
-    target_id = format_task_id(configurable_class_name)
-    target_node = nodes.target('', '', ids=[target_id])
-
-    # Store these task/configurable topic nodes in the environment for later
-    # cross referencing.
-    if not hasattr(env, 'lsst_tasks'):
-        env.lsst_tasks = {}
-    env.lsst_tasks[target_id] = {
-        'docname': env.docname,
-        'lineno': lineno,
-        'target': target_node,
-        'is_task': False
-    }
-
-    return target_node
-
-
-class ConfigTopicTargetDirective(Directive):
-    """``lsst-config-topic`` directive that labels a Config topic page.
-
-    Configs are lsst.pex.config.config.Config subclasses.
-    """
-
-    directive_name = 'lsst-config-topic'
-    """Default name of this directive.
-    """
-
-    has_content = False
-
-    required_arguments = 1
-
-    def run(self):
-        """Main entrypoint method.
-
-        Returns
-        -------
-        new_nodes : `list`
-            Nodes to add to the doctree.
-        """
-        env = self.state.document.settings.env
-        logger = getLogger(__name__)
-
-        try:
-            config_class_name = self.arguments[0]
-        except IndexError:
-            raise SphinxError(
-                '{} directive requires a Config class name as an '
-                'argument'.format(self.directive_name)
-            )
-        logger.debug('%s using Config class %s',
-                     self.directive_name, config_class_name)
-
-        target_id = format_config_id(config_class_name)
-        target_node = nodes.target('', '', ids=[target_id])
-
-        # Store these config topic nodes in the environment for later
-        # cross referencing.
-        if not hasattr(env, 'lsst_configs'):
-            env.lsst_configs = {}
-        env.lsst_configs[target_id] = {
-            'docname': env.docname,
-            'lineno': self.lineno,
-            'target': target_node,
-        }
-
-        return [target_node]
 
 
 class pending_task_xref(nodes.Inline, nodes.Element):
@@ -302,10 +146,11 @@ def process_pending_task_xref_nodes(app, doctree, fromdocname):
         link_label = nodes.literal()
         link_label += nodes.Text(display_text, display_text)
 
-        if hasattr(env, 'lsst_tasks') and task_id in env.lsst_tasks:
+        if hasattr(env, 'lsst_task_topics') and \
+                task_id in env.lsst_task_topics:
             # A task topic, marked up with the lsst-task-topic directive is
             # available
-            task_data = env.lsst_tasks[task_id]
+            task_data = env.lsst_task_topics[task_id]
 
             ref_node = nodes.reference('', '')
             ref_node['refdocname'] = task_data['docname']
@@ -398,10 +243,11 @@ def process_pending_config_xref_nodes(app, doctree, fromdocname):
         link_label = nodes.literal()
         link_label += nodes.Text(display_text, display_text)
 
-        if hasattr(env, 'lsst_configs') and config_id in env.lsst_configs:
+        if hasattr(env, 'lsst_task_topics') and \
+                config_id in env.lsst_task_topics:
             # A config topic, marked up with the lsst-task directive is
             # available
-            config_data = env.lsst_configs[config_id]
+            config_data = env.lsst_task_topics[config_id]
 
             ref_node = nodes.reference('', '')
             ref_node['refdocname'] = config_data['docname']

--- a/documenteer/sphinxext/lssttasks/pyapisummary.py
+++ b/documenteer/sphinxext/lssttasks/pyapisummary.py
@@ -8,13 +8,12 @@ from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.errors import SphinxError
 from sphinx.util.logging import getLogger
-from sphinx.util.inspect import getdoc, Signature
-from sphinx.util.docstrings import prepare_docstring
+from sphinx.util.inspect import Signature
 from sphinx.addnodes import (desc, desc_signature, desc_content, desc_addname,
                              desc_annotation, seealso)
 from sphinx.domains.python import _pseudo_parse_arglist, PyXRefRole
 
-from .taskutils import get_type
+from .taskutils import get_type, get_docstring, extract_docstring_summary
 
 
 class TaskApiDirective(Directive):
@@ -302,46 +301,3 @@ class TaskApiDirective(Directive):
         seealso_node += p_node
 
         return [seealso_node]
-
-
-def get_docstring(obj):
-    """Extract the docstring from an object as individual lines.
-
-    Parameters
-    ----------
-    obj : object
-        The Python object (class, function or method) to extract docstrings
-        from.
-
-    Returns
-    -------
-    lines : `list` of `str`
-        Individual docstring lines with common indentation removed, and
-        newline characters stripped.
-    """
-    docstring = getdoc(obj, allow_inherited=True)
-    # ignore is simply the number of initial lines to ignore when determining
-    # the docstring's baseline indent level. We really want "1" here.
-    return prepare_docstring(docstring, ignore=1)
-
-
-def extract_docstring_summary(docstring):
-    """Get the first summary sentence from a docstring.
-
-    Parameters
-    ----------
-    docstring : `list` of `str`
-        Output from `get_docstring`.
-
-    Returns
-    -------
-    summary : `str`
-        The plain-text summary sentence from teh docstring.
-    """
-    summary_lines = []
-    for line in docstring:
-        if line == '':
-            break
-        else:
-            summary_lines.append(line)
-    return ' '.join(summary_lines)

--- a/documenteer/sphinxext/lssttasks/taskutils.py
+++ b/documenteer/sphinxext/lssttasks/taskutils.py
@@ -2,12 +2,15 @@
 """
 
 __all__ = ('get_task_config_class', 'get_task_config_fields',
-           'get_subtask_fields', 'typestring', 'get_type')
+           'get_subtask_fields', 'typestring', 'get_type',
+           'get_docstring', 'extract_docstring_summary')
 
 from importlib import import_module
 import inspect
 
 from sphinx.errors import SphinxError
+from sphinx.util.inspect import getdoc
+from sphinx.util.docstrings import prepare_docstring
 
 
 def get_task_config_class(task_name):
@@ -157,3 +160,46 @@ def typestring(obj):
     """
     obj_type = type(obj)
     return '.'.join((obj_type.__module__, obj_type.__name__))
+
+
+def get_docstring(obj):
+    """Extract the docstring from an object as individual lines.
+
+    Parameters
+    ----------
+    obj : object
+        The Python object (class, function or method) to extract docstrings
+        from.
+
+    Returns
+    -------
+    lines : `list` of `str`
+        Individual docstring lines with common indentation removed, and
+        newline characters stripped.
+    """
+    docstring = getdoc(obj, allow_inherited=True)
+    # ignore is simply the number of initial lines to ignore when determining
+    # the docstring's baseline indent level. We really want "1" here.
+    return prepare_docstring(docstring, ignore=1)
+
+
+def extract_docstring_summary(docstring):
+    """Get the first summary sentence from a docstring.
+
+    Parameters
+    ----------
+    docstring : `list` of `str`
+        Output from `get_docstring`.
+
+    Returns
+    -------
+    summary : `str`
+        The plain-text summary sentence from the docstring.
+    """
+    summary_lines = []
+    for line in docstring:
+        if line == '':
+            break
+        else:
+            summary_lines.append(line)
+    return ' '.join(summary_lines)

--- a/documenteer/sphinxext/lssttasks/topiclists.py
+++ b/documenteer/sphinxext/lssttasks/topiclists.py
@@ -1,0 +1,257 @@
+"""Directives that list and create toctrees of task framework topics.
+"""
+
+__all__ = ('TaskListDirective', 'CmdLineTaskListDirective',
+           'PipelineTaskListDirective', 'ConfigurableListDirective',
+           'ConfigListDirective', 'task_topic_list', 'process_task_topic_list')
+
+import posixpath
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+import sphinx.addnodes
+from sphinx.util.logging import getLogger
+
+
+class BaseTopicListDirective(Directive):
+    """Base class for directives that lists task topics.
+    """
+
+    _logger = getLogger(__name__)
+
+    required_arguments = 0
+    optional_arguments = 0
+    has_content = False
+    option_spec = {
+        'root': directives.unchanged,
+        'toctree': directives.unchanged
+    }
+
+    @property
+    def types(self):
+        """The set of types that this directive lists.
+
+        "Types" themselves are strings:
+
+        - ``'Task'``
+        - ``'PipelineTask'``
+        - ``'CmdLineTask'``
+        - ``'Configurable'``
+        - ``'Config'``
+
+        These names correspond to the ``'types'`` key of the
+        ``lsst_task_topics`` environment attribute set by the
+        topic marker directives (such as
+        `documenteer.sphinxext.lssttasks.topics.TaskTopicDirective`).
+        """
+        raise NotImplementedError
+
+    def run(self):
+        """Main entrypoint method.
+
+        Returns
+        -------
+        new_nodes : `list`
+            Nodes to add to the doctree.
+        """
+        self._env = self.state.document.settings.env
+
+        nodes = []
+
+        if 'toctree' in self.options:
+            # Insert a hidden toctree
+            toctree_node = self._build_toctree()
+            nodes.append(toctree_node)
+
+        # Placeholder node rendered in `process_task_topic_list`
+        list_node = task_topic_list()
+        list_node['types'] = self.types
+        list_node['root_namespace'] = self.options['root']
+        nodes.append(list_node)
+
+        return nodes
+
+    def _build_toctree(self):
+        """Create a hidden toctree node with the contents of a directory
+        prefixed by the directory name specified by the `toctree` directive
+        option.
+        """
+        dirname = posixpath.dirname(self._env.docname)
+        tree_prefix = self.options['toctree'].strip()
+        root = posixpath.normpath(posixpath.join(dirname, tree_prefix))
+        docnames = [docname for docname in self._env.found_docs
+                    if docname.startswith(root)]
+
+        # Sort docnames alphabetically based on **class** name.
+        # The standard we assume is that task doc pages are named after
+        # their Python namespace.
+        # NOTE: this ordering only applies to the toctree; the visual ordering
+        # is set by `process_task_topic_list`.
+        # NOTE: docnames are **always** POSIX-like paths
+        class_names = [docname.split('/')[-1].split('.')[-1]
+                       for docname in docnames]
+        docnames = [docname for docname, _ in
+                    sorted(zip(docnames, class_names),
+                           key=lambda pair: pair[1])]
+
+        tocnode = sphinx.addnodes.toctree()
+        tocnode['includefiles'] = docnames
+        tocnode['entries'] = [(None, docname) for docname in docnames]
+        tocnode['maxdepth'] = -1
+        tocnode['glob'] = None
+        tocnode['hidden'] = True
+
+        return tocnode
+
+
+class TaskListDirective(BaseTopicListDirective):
+    """``lsst-tasks`` directive that creates a toctree of LSST task topics
+    (specifically subclasses of ``lsst.pipe.base.Task``, but not including
+    subclasses of ``lsst.pipe.base.CmdLineTask`` or
+    ``lsst.pipe.base.PipelineTask``).
+    """
+
+    directive_name = 'lsst-tasks'
+    """Default name of this directive.
+    """
+
+    @property
+    def types(self):
+        return set(('Task',))
+
+
+class CmdLineTaskListDirective(BaseTopicListDirective):
+    """``lsst-tasks`` directive that creates a toctree of LSST command-line
+    tasks (``lsst.pipe.base.CmdLineTask``).
+    """
+
+    directive_name = 'lsst-cmdlinetasks'
+    """Default name of this directive.
+    """
+
+    @property
+    def types(self):
+        return set(('CmdLineTask',))
+
+
+class PipelineTaskListDirective(BaseTopicListDirective):
+    """``lsst-tasks`` directive that creates a toctree of LSST pipeline
+    tasks (``lsst.pipe.base.PipelineTask``).
+    """
+
+    directive_name = 'lsst-pipelinetasks'
+    """Default name of this directive.
+    """
+
+    @property
+    def types(self):
+        return set(('PipelineTask',))
+
+
+class ConfigurableListDirective(BaseTopicListDirective):
+
+    directive_name = 'lsst-configurables'
+
+    @property
+    def types(self):
+        return set(('Configurable',))
+
+
+class ConfigListDirective(TaskListDirective):
+
+    directive_name = 'lsst-configs'
+
+    @property
+    def types(self):
+        return set(('Config',))
+
+
+class task_topic_list(nodes.comment):
+    """Placeholder node for a task topic listing.
+
+    This node is processed by `process_task_topic_list`.
+    """
+
+
+def process_task_topic_list(app, doctree, fromdocname):
+    """Process the ``task_topic_list`` node to generate a rendered listing of
+    Task, Configurable, or Config topics (as determined by the types
+    key of the ``task_topic_list`` node).
+
+    This is called during the "doctree-resolved" phase so that the
+    ``lsst_task_topcs`` environment attribute is fully set.
+    """
+    logger = getLogger(__name__)
+    logger.debug('Started process_task_list')
+
+    env = app.builder.env
+
+    for node in doctree.traverse(task_topic_list):
+        try:
+            topics = env.lsst_task_topics
+        except AttributeError:
+            message = (
+                "Environment does not have 'lsst_task_topics', "
+                "can't process the listing."
+            )
+            logger.warning(message)
+            node.replace_self(nodes.paragraph(text=message))
+            continue
+
+        root = node['root_namespace']
+
+        # Sort tasks by the topic's class name.
+        # NOTE: if the presentation of the link is changed to the fully
+        # qualified name, with full Python namespace, then the topic_names
+        # should be changed to match that.
+        topic_keys = [k for k, topic in topics.items()
+                      if topic['type'] in node['types']
+                      if topic['fully_qualified_name'].startswith(root)]
+        topic_names = [topics[k]['fully_qualified_name'].split('.')[-1]
+                       for k in topic_keys]
+        topic_keys = [
+            k for k, _ in
+            sorted(zip(topic_keys, topic_names), key=lambda pair: pair[1])]
+
+        if len(topic_keys) == 0:
+            # Fallback if no topics are found
+            p = nodes.paragraph(text='No topics.')
+            node.replace_self(p)
+            continue
+
+        dl = nodes.definition_list()
+        for key in topic_keys:
+            topic = topics[key]
+            class_name = topic['fully_qualified_name'].split('.')[-1]
+            summary_text = topic['summary_node'][0].astext()
+
+            # Each topic in the listing is a definition list item. The term is
+            # the linked class name and the description is the summary
+            # sentence from the docstring _or_ the content of the
+            # topic directive
+            dl_item = nodes.definition_list_item()
+
+            # Can insert an actual reference since the doctree is resolved.
+            ref_node = nodes.reference('', '')
+            ref_node['refdocname'] = topic['docname']
+            ref_node['refuri'] = app.builder.get_relative_uri(
+                fromdocname, topic['docname'])
+            # NOTE: Not appending an anchor to the URI because task topics
+            # are designed to occupy an entire page.
+            link_label = nodes.Text(class_name, class_name)
+            ref_node += link_label
+
+            term = nodes.term()
+            term += ref_node
+            dl_item += term
+
+            # We're degrading the summary to plain text to avoid syntax issues
+            # and also because it may be distracting
+            def_node = nodes.definition()
+            def_node += nodes.paragraph(text=summary_text)
+            dl_item += def_node
+            dl += dl_item
+
+        # Replace the task_list node (a placeholder) with this renderable
+        # content
+        node.replace_self(dl)

--- a/documenteer/sphinxext/lssttasks/topics.py
+++ b/documenteer/sphinxext/lssttasks/topics.py
@@ -1,0 +1,161 @@
+"""Directives that mark task and configurable topics for the LSST Science
+Pipelines documentation.
+"""
+
+__all__ = ('ConfigurableTopicDirective', 'TaskTopicDirective',
+           'ConfigTopicDirective')
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.errors import SphinxError
+from sphinx.util.logging import getLogger
+from sphinx.util.docutils import switch_source_input
+
+from .crossrefs import format_task_id, format_config_id
+from .taskutils import get_type, get_docstring, extract_docstring_summary
+from ..utils import parse_rst_content
+
+
+class BaseTopicDirective(Directive):
+    """Base for topic target directives.
+    """
+
+    _logger = getLogger(__name__)
+
+    has_content = True
+    required_arguments = 1
+
+    @property
+    def directive_name(self):
+        raise NotImplementedError
+
+    def get_type(self, class_name):
+        """Get the topic type.
+        """
+        raise NotImplementedError
+
+    def get_target_id(self, class_name):
+        """Get the reference ID for this topic directive.
+        """
+        raise NotImplementedError
+
+    def run(self):
+        """Main entrypoint method.
+
+        Returns
+        -------
+        new_nodes : `list`
+            Nodes to add to the doctree.
+        """
+        env = self.state.document.settings.env
+
+        try:
+            class_name = self.arguments[0]
+        except IndexError:
+            raise SphinxError(
+                '{0} directive requires a class name as an '
+                'argument'.format(self.directive_name)
+            )
+        self._logger.debug('%s using class %s',
+                           self.directive_name, class_name)
+
+        summary_node = self._create_summary_node(class_name)
+
+        # target_id = format_task_id(class_name)
+        target_id = self.get_target_id(class_name)
+        target_node = nodes.target('', '', ids=[target_id])
+
+        # Store these task/configurable topic nodes in the environment for
+        # later cross referencing.
+        if not hasattr(env, 'lsst_task_topics'):
+            env.lsst_task_topics = {}
+        env.lsst_task_topics[target_id] = {
+            'docname': env.docname,
+            'lineno': self.lineno,
+            'target': target_node,
+            'summary_node': summary_node,
+            'fully_qualified_name': class_name,
+            'type': self.get_type(class_name)
+        }
+
+        return [target_node]
+
+    def _create_summary_node(self, class_name):
+        if len(self.content) > 0:
+            # Try to get the summary content from the directive content
+            container_node = nodes.container()
+            container_node.document = self.state.document
+            content_view = self.content
+            with switch_source_input(self.state, content_view):
+                self.state.nested_parse(content_view, 0, container_node)
+            return container_node.children
+
+        else:
+            # Fallback is to get summary sentence from class docstring.
+            return self._get_docstring_summary(class_name)
+
+    def _get_docstring_summary(self, class_name):
+        obj = get_type(class_name)
+        summary_text = extract_docstring_summary(get_docstring(obj))
+        if summary_text == '':
+            summary_text = 'No description available.'
+        summary_text = summary_text.strip() + '\n'
+        return parse_rst_content(summary_text, self.state)
+
+
+class ConfigurableTopicDirective(BaseTopicDirective):
+    """``lsst-configurable-topic`` directive that labels a Configurable's topic
+    page.
+
+    Configurables are essentially generalized tasks. They have a ConfigClass,
+    but don't have run methods.
+    """
+
+    directive_name = 'lsst-configurable-topic'
+    """Default name of this directive.
+    """
+
+    def get_type(self, class_name):
+        return 'Configurable'
+
+    def get_target_id(self, class_name):
+        return format_task_id(class_name)
+
+
+class TaskTopicDirective(BaseTopicDirective):
+    """``lsst-task-topic`` directive that labels a Task's topic page.
+    """
+
+    directive_name = 'lsst-task-topic'
+    """Default name of this directive.
+    """
+
+    def get_type(self, class_name):
+        from lsst.pipe.base import CmdLineTask, PipelineTask
+        obj = get_type(class_name)
+        if issubclass(obj, PipelineTask):
+            return 'PipelineTask'
+        elif issubclass(obj, CmdLineTask):
+            return 'CmdLineTask'
+        else:
+            return 'Task'
+
+    def get_target_id(self, class_name):
+        return format_task_id(class_name)
+
+
+class ConfigTopicDirective(BaseTopicDirective):
+    """``lsst-config-topic`` directive that labels a Config topic page.
+
+    Configs are lsst.pex.config.config.Config subclasses.
+    """
+
+    directive_name = 'lsst-config-topic'
+    """Default name of this directive.
+    """
+
+    def get_type(self, class_name):
+        return 'Config'
+
+    def get_target_id(self, class_name):
+        return format_config_id(class_name)

--- a/documenteer/sphinxext/lssttasks/topics.py
+++ b/documenteer/sphinxext/lssttasks/topics.py
@@ -14,6 +14,7 @@ from sphinx.util.docutils import switch_source_input
 from .crossrefs import format_task_id, format_config_id
 from .taskutils import get_type, get_docstring, extract_docstring_summary
 from ..utils import parse_rst_content
+from . import extension
 
 
 class BaseTopicDirective(Directive):
@@ -26,7 +27,7 @@ class BaseTopicDirective(Directive):
     required_arguments = 1
 
     @property
-    def directive_name(self):
+    def name(self):
         raise NotImplementedError
 
     def get_type(self, class_name):
@@ -54,10 +55,10 @@ class BaseTopicDirective(Directive):
         except IndexError:
             raise SphinxError(
                 '{0} directive requires a class name as an '
-                'argument'.format(self.directive_name)
+                'argument'.format(self.name)
             )
         self._logger.debug('%s using class %s',
-                           self.directive_name, class_name)
+                           self.name, class_name)
 
         summary_node = self._create_summary_node(class_name)
 
@@ -103,6 +104,7 @@ class BaseTopicDirective(Directive):
         return parse_rst_content(summary_text, self.state)
 
 
+@extension.directive
 class ConfigurableTopicDirective(BaseTopicDirective):
     """``lsst-configurable-topic`` directive that labels a Configurable's topic
     page.
@@ -111,7 +113,7 @@ class ConfigurableTopicDirective(BaseTopicDirective):
     but don't have run methods.
     """
 
-    directive_name = 'lsst-configurable-topic'
+    name = 'lsst-configurable-topic'
     """Default name of this directive.
     """
 
@@ -122,11 +124,12 @@ class ConfigurableTopicDirective(BaseTopicDirective):
         return format_task_id(class_name)
 
 
+@extension.directive
 class TaskTopicDirective(BaseTopicDirective):
     """``lsst-task-topic`` directive that labels a Task's topic page.
     """
 
-    directive_name = 'lsst-task-topic'
+    name = 'lsst-task-topic'
     """Default name of this directive.
     """
 
@@ -144,13 +147,14 @@ class TaskTopicDirective(BaseTopicDirective):
         return format_task_id(class_name)
 
 
+@extension.directive
 class ConfigTopicDirective(BaseTopicDirective):
     """``lsst-config-topic`` directive that labels a Config topic page.
 
     Configs are lsst.pex.config.config.Config subclasses.
     """
 
-    directive_name = 'lsst-config-topic'
+    name = 'lsst-config-topic'
     """Default name of this directive.
     """
 


### PR DESCRIPTION
Demo:

```py
from docutils import nodes                                              
from docutils.parsers.rst import Directive                              
                                                                        
from documenteer.sphinxext.utils import SphinxExtension                 
                                                                        
                                                                        
# module-level instance. All members of the Sphinx extension refer to   
# this instance.                                                        
extension = SphinxExtension()                                           
                                                                        
# Decorate a directive class to register it with the extension          
@extension.directive                                                    
def MyDirective(Directive):                                             
                                                                        
    # By putting a ``name`` attribute in your directive, SphinxExtension
    # will use that name for the directive name.                        
    name = "my-directive"                                               
                                                                        
    def run(self):                                                      
        return [nodes.paragraph(text='Hello world')                     
                                                                        
# Now your setup function just calls the setup method on the            
# SphinxExtension instance                                              
def setup():                                                            
    extension.setup()                                                   
```