### PR TITLE
DM-16102: Enable automodsumm_inherited_members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
     These listings not only link to the topic, but also show a summary that's either extracted from the corresponding docstring or set through the ``lsst-task-topic`` or ``lsst-config-topic`` directives.
     These directives also generate a toctree.
 
+
+- Added Astropy to the intersphinx configuration.
+
+- Enabled ``automodsumm_inherited_members`` in the stackconf for stack documentation.
+  This configuration is critical:
+
+  1. It is actually responsible for ensuring that inherited members of classes appear in our docs.
+  2. Without this, classes that have a ``__slots__`` attribute (typically through inheritance of a ``collections.abc`` class) won't have *any* of their members documented. See https://jira.lsstcorp.org/browse/DM-16102 for discussion.
+
 0.3.0 (2018-09-19)
 ------------------
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -57,6 +57,7 @@ def _insert_intersphinx_mapping(c):
         'matplotlib': ('https://matplotlib.org/', None),
         'sklearn': ('http://scikit-learn.org/stable/', None),
         'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
+        'astropy': ('http://docs.astropy.org/en/v3.0.x/', None),
     }
     c['intersphinx_timeout'] = 10.0  # seconds
     c['intersphinx_cache_limit'] = 5  # days

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -223,6 +223,7 @@ def _insert_automodapi_configs(c):
     c['autosummary_generate'] = True
 
     c['automodapi_toctreedirnm'] = 'py-api'
+    c['automodsumm_inherited_members'] = True
 
     # Docstrings for classes and methods are inherited from parents.
     c['autodoc_inherit_docstrings'] = True


### PR DESCRIPTION
- Added Astropy to the intersphinx configuration.

- Enabled `automodsumm_inherited_members` in the stackconf for stack documentation. This configuration is critical:

   1. It is actually responsible for ensuring that inherited members of classes appear in our docs.
   2. Without this, classes that have a `__slots__` attribute (typically through inheritance of a `collections.abc` class) won't have *any* of their members documented. See https://jira.lsstcorp.org/browse/DM-16102 for discussion.