### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,6 @@ Unreleased
     These listings not only link to the topic, but also show a summary that's either extracted from the corresponding docstring or set through the ``lsst-task-topic`` or ``lsst-config-topic`` directives.
     These directives also generate a toctree.
 
-
 - Added Astropy to the intersphinx configuration.
 
 - Enabled ``automodsumm_inherited_members`` in the stackconf for stack documentation.
@@ -24,6 +23,9 @@ Unreleased
 
   1. It is actually responsible for ensuring that inherited members of classes appear in our docs.
   2. Without this, classes that have a ``__slots__`` attribute (typically through inheritance of a ``collections.abc`` class) won't have *any* of their members documented. See https://jira.lsstcorp.org/browse/DM-16102 for discussion.
+
+- ``todo`` directives are now hidden when using ``build_pipelines_lsst_io_configs``.
+  They are still shown, by default, for standalone package documentation builds, which are primarily developer-facing.
 
 0.3.0 (2018-09-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.4.0 (2018-10-14)
+------------------
 
 - New directives and roles for documenting tasks in LSST Science Pipelines.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,11 @@ intersphinx_mapping = {
 
 linkcheck_retries = 2
 
+# Since Jira is currently down at this time
+linkcheck_ignore = [r'^https://jira.lsstcorp.org/browse/']
+
+linkcheck_timeout = 15
+
 # -- Options for HTML output ----------------------------------------------
 
 templates_path = [

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -36,7 +36,6 @@ def _insert_extensions(c):
         'sphinx_automodapi.smart_resolver',
         'breathe',
         'documenteer.sphinxext',
-        'documenteer.sphinxext.lssttasks',
     ]
     return c
 
@@ -380,10 +379,8 @@ def build_package_configs(project_name,
     if copyright is not None:
         c['copyright'] = copyright
     else:
-        # Use this copyright for now. Ultimately we want to gather COPYRIGHT
-        # files and build an integrated copyright that way.
-        c['copyright'] = '2015-{year} LSST contributors.'.format(
-            year=date.year)
+        c['copyright'] = 'Copyright {:s} LSST contributors.'.format(
+            date.strftime('%Y-%m-%d'))
     c['version'] = version
     c['release'] = version
 
@@ -496,7 +493,7 @@ def build_pipelines_lsst_io_configs(*, project_name, current_release,
     c['exclude_patterns'] = ['_build', 'README.rst']
 
     # Hide todo directives in the "published" documentation on the main site.
-    c['todo_include_todos'] = True
+    c['todo_include_todos'] = False
 
     # List of patterns, relative to source directory, that match files and
     # directories to ignore when looking for source files.


### PR DESCRIPTION
Release for 0.4.0, which includes the new task documentation extensions, and also hides todo entries from the pipelines.lsst.io build.