### PR TITLE
Release version 0.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.4.1 (2018-10-15)
+------------------
+
+- Add ``documenteer.sphinxext.lssttasks`` to the Sphinx extensions available for pipelines.lsst.io documentation builds.
+
+- For pipelines.lsst.io builds, Documenteer ignores the ``home/`` directory that's created at the root of the ``pipelines_lsst_io`` directory.
+  This directory is created as part of the ci.lsst.codes ``sqre/infra/documenteer`` job and shouldn't be part of the documentation build.
+
 0.4.0 (2018-10-14)
 ------------------
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -36,6 +36,7 @@ def _insert_extensions(c):
         'sphinx_automodapi.smart_resolver',
         'breathe',
         'documenteer.sphinxext',
+        'documenteer.sphinxext.lssttasks'
     ]
     return c
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -489,16 +489,13 @@ def build_pipelines_lsst_io_configs(*, project_name, current_release,
     c['version'] = current_release
     c['release'] = current_release
 
-    # List of patterns, relative to source directory, that match files and
-    # directories to ignore when looking for source files.
-    c['exclude_patterns'] = ['_build', 'README.rst']
-
     # Hide todo directives in the "published" documentation on the main site.
     c['todo_include_todos'] = False
 
     # List of patterns, relative to source directory, that match files and
     # directories to ignore when looking for source files.
     c['exclude_patterns'] = [
+        'README.rst',
         # Build products
         '_build',
         # Source for release notes (contents are included in built pages)
@@ -510,6 +507,11 @@ def build_pipelines_lsst_io_configs(*, project_name, current_release,
         '.pyvenv',
         # GitHub templates
         '.github',
+        # This 'home' directory is created by the docubase image for the
+        # sqre/infra/documenteer ci.lsst.codes Jenkins job. Ideally this
+        # shouldn't be in the directory at all, but we certainly need to
+        # ignore it while its here.
+        'home',
     ]
 
     # Substitutions available on every page


### PR DESCRIPTION
Fixes included in this release:

- Add `documenteer.sphinxext.lssttasks` to the Sphinx extensions available for pipelines.lsst.io documentation builds.
 - For pipelines.lsst.io builds, Documenteer ignores the `home/` directory that's created at the root of the `pipelines_lsst_io` directory. This directory is created as part of the ci.lsst.codes `sqre/infra/documenteer` job and shouldn't be part of the documentation build.