### PR TITLE
DM-17661: Support ConfigurableWrapper-type items in lsst-task-config-subtasks directive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Updated scikit-learn's intersphinx inventory URL (now available as HTTPS) in the ``documenteer.sphinxconfig.stackconf``.
+- Fixed the ``lsst-task-config-subtasks`` directive so that it can introspect items in an ``lsst.pex.config`` ``Registry`` that are wrapped by a ``ConfigurableWrapper``. :jira:`DM-17661`.
 
 0.4.3 (2018-11-30)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.4.4 (2019-02-05)
+------------------
 
 - Updated scikit-learn's intersphinx inventory URL (now available as HTTPS) in the ``documenteer.sphinxconfig.stackconf``.
 - Fixed the ``lsst-task-config-subtasks`` directive so that it can introspect items in an ``lsst.pex.config`` ``Registry`` that are wrapped by a ``ConfigurableWrapper``. :jira:`DM-17661`.


### PR DESCRIPTION
If an item in an `lsst.pex.config.Registry` is wrapped in a `ConfigurableWrapper` than it does not have `__module__` and `__name__` attributes like most tasks seem to. Instead, the task itself is accessible from a `_target` attribute on the `ConfigurableWrapper`.

To handle the most generic case, the introduction can also fall back to accessing the `__class__` attribute and getting the `__module__` and `__name__` attributes from that.