### PR TITLE
DM-17065: Add sphinx-jinja extension and EUPS_TAG-driven variables for pipelines.lsst.io installation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,33 @@ Unreleased
   Before, a package only needed a ``doc/manifest.yaml`` file and to be currently set up in the EUPS environment to be linked into the documentation build.
   This would lead to packages being included in a documentation build despite not being a part of that stack product.
 
+- This release adds the `sphinx-jinja`_ extension for ``documenteer[pipelines]`` installations.
+  This extension makes it possible to dynamically create content with Jinja templating.
+
+  The ``documenteer.sphinxconfig.stackconf`` module sets up a ``default`` context for the ``jinja`` directive that includes all module attributes in the Sphinx config module.
+
+- The ``documenteer.sphinxconfig.stackconf`` module includes several new configuration attributes that are driven by the presence of an ``EUPS_TAG`` environment variable.
+  The overall intent of these variables is to make it possible to render installation documentation for the https://pipelines.lsst.io documentation project from the ``EUPS_TAG`` environment variable.
+  The variables are:
+
+  - ``release_eups_tag``
+  - ``release_git_ref``
+  - ``release``
+  - ``version``
+  - ``scipipe_conda_ref``
+  - ``newinstall_ref``
+  - ``pipelines_demo_ref``
+
+  These variables are accessible from the ``jinja`` directive's context.
+
+- This release also added some new substitutions to the ``rst_epilog`` of stack-based projects:
+
+  - ``|eups-tag|`` --- the current EUPS tag, based on the ``EUPS_TAG`` environment variable.
+  - ``|eups-tag-mono|`` --- monospace typeface version of ``|eups-tag|``.
+  - ``|eups-tag-bold|`` --- bold typeface version of ``|eups-tag|``.
+
+- Fixed some bugs with the display of copyrights in stack-based projects.
+
 0.4.5 (2019-02-06)
 ------------------
 
@@ -260,3 +287,4 @@ Includes prototype support for LSST Science Pipelines documentation, as part of 
 .. _astropy_helpers: https://pypi.org/project/astropy-helpers/
 .. _`sphinx-automodapi`: https://pypi.org/project/sphinx-automodapi/
 .. _numpydoc: https://pypi.org/project/numpydoc/
+.. _sphinx-jinja: https://github.com/tardyp/sphinx-jinja

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -380,8 +380,8 @@ def build_package_configs(project_name,
     if copyright is not None:
         c['copyright'] = copyright
     else:
-        c['copyright'] = 'Copyright {:s} LSST contributors.'.format(
-            date.strftime('%Y-%m-%d'))
+        c['copyright'] = '{:s} LSST contributors'.format(
+            date.strftime('%Y'))
     c['version'] = version
     c['release'] = version
 
@@ -482,7 +482,7 @@ def build_pipelines_lsst_io_configs(*, project_name, current_release,
 
     # Use this copyright for now. Ultimately we want to gather COPYRIGHT files
     # and build an integrated copyright that way.
-    c['copyright'] = '2015-{year} LSST contributors.'.format(
+    c['copyright'] = '2015-{year} LSST contributors'.format(
         year=date.year)
 
     # Always define the "version" as the EUPS tag of the latest release.

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -30,6 +30,7 @@ def _insert_extensions(c):
         'sphinx.ext.coverage',
         'sphinx.ext.mathjax',
         'sphinx.ext.ifconfig',
+        'sphinxcontrib.jinja',
         'sphinx-prompt',
         'numpydoc',
         'sphinx_automodapi.automodapi',

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -330,6 +330,22 @@ def _insert_eups_version(c, eups_version=None):
     return c
 
 
+def _insert_rst_epilog(c):
+    """Insert the rst_epilog variable into the configuration.
+
+    This should be applied after other configurations so that the epilog can
+    use other configuration variables.
+    """
+    # Substitutions available on every page
+    c['rst_epilog'] = """
+.. |eups-tag| replace:: {eups_tag}
+.. |eups-tag-mono| replace:: ``{eups_tag}``
+.. |eups-tag-bold| replace:: **{eups_tag}**
+    """.format(eups_tag=c['release_eups_tag'])
+
+    return c
+
+
 def build_package_configs(project_name,
                           version=None,
                           copyright=None,
@@ -437,6 +453,9 @@ def build_package_configs(project_name,
     # Show rendered todo directives in package docs since they're developer
     # facing.
     c['todo_include_todos'] = True
+
+    # Insert rst_epilog configuration
+    c = _insert_rst_epilog(c)
 
     return c
 
@@ -549,11 +568,7 @@ def build_pipelines_lsst_io_configs(*, project_name, copyright=None):
         'home',
     ]
 
-    # Substitutions available on every page
-    c['rst_epilog'] = """
-.. |eups-tag| replace:: {eups_tag}
-.. |eups-tag-mono| replace:: ``{eups_tag}``
-.. |eups-tag-bold| replace:: **{eups_tag}**
-    """.format(eups_tag=c['release_eups_tag'])
+    # Insert rst_epilog configuration
+    c = _insert_rst_epilog(c)
 
     return c

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -347,6 +347,17 @@ def _insert_rst_epilog(c):
     return c
 
 
+def _insert_jinja_configuration(c):
+    """Insert the configuration for the sphinx-jinja extension.
+
+    The "default" Jinja context includes all variables in the conf.py
+    configuration namespace.
+    """
+    c['jinja_contexts'] = {'default': c}
+
+    return c
+
+
 def build_package_configs(project_name,
                           version=None,
                           copyright=None,
@@ -457,6 +468,9 @@ def build_package_configs(project_name,
 
     # Insert rst_epilog configuration
     c = _insert_rst_epilog(c)
+
+    # Set up the context for the sphinx-jinja extension
+    c = _insert_jinja_configuration(c)
 
     return c
 
@@ -571,5 +585,8 @@ def build_pipelines_lsst_io_configs(*, project_name, copyright=None):
 
     # Insert rst_epilog configuration
     c = _insert_rst_epilog(c)
+
+    # Set up the context for the sphinx-jinja extension
+    c = _insert_jinja_configuration(c)
 
     return c

--- a/documenteer/sphinxconfig/utils.py
+++ b/documenteer/sphinxconfig/utils.py
@@ -8,10 +8,10 @@ import git
 
 from sphinx.util.matching import Matcher
 
-TICKET_BRANCH_PATTERN = re.compile('^tickets/([A-Z]+-[0-9]+)$')
+TICKET_BRANCH_PATTERN = re.compile(r'^tickets/([A-Z]+-[0-9]+)$')
 
 # does it start with vN and look like a version tag?
-TAG_PATTERN = re.compile('^v\d')
+TAG_PATTERN = re.compile(r'^v\d')
 
 
 def read_git_branch():
@@ -24,7 +24,7 @@ def read_git_branch():
         try:
             repo = git.repo.base.Repo(search_parent_directories=True)
             return repo.active_branch.name
-        except:
+        except Exception:
             return ''
 
 

--- a/documenteer/sphinxext/lssttasks/configfieldlists.py
+++ b/documenteer/sphinxext/lssttasks/configfieldlists.py
@@ -1088,7 +1088,7 @@ def create_description_node(field, state):
     Returns
     -------
     ``docutils.nodes.section``
-        Section containing nodes for the ``field``\ 's description.
+        Section containing nodes for the description of the ``field``.
     """
     doc_container_node = nodes.container()
     doc_container_node += parse_rst_content(field.doc, state)
@@ -1110,7 +1110,7 @@ def create_title_node(field_name, field, field_id, state, lineno):
     Returns
     -------
     ``docutils.nodes.title``
-        Title containing nodes for the ``field``\ 's title and reference
+        Title containing nodes for the title of the ``field`` and reference
         target.
     """
     # Reference target

--- a/documenteer/sphinxext/lssttasks/taskutils.py
+++ b/documenteer/sphinxext/lssttasks/taskutils.py
@@ -24,7 +24,7 @@ def get_task_config_class(task_name):
 
     Returns
     -------
-    config_class : ``lsst.pipe.base.Config``\ -type
+    config_class : ``lsst.pipe.base.Config``-type
         The configuration class (not an instance) corresponding to the task.
     """
     task_class = get_type(task_name)
@@ -61,7 +61,7 @@ def get_task_config_fields(config_class):
 
     Parameters
     ----------
-    config_class : ``lsst.pipe.base.Config``\ -type
+    config_class : ``lsst.pipe.base.Config``-type
         The configuration class (not an instance) corresponding to a Task.
 
     Returns
@@ -84,7 +84,7 @@ def get_subtask_fields(config_class):
 
     Parameters
     ----------
-    config_class : ``lsst.pipe.base.Config``\ -type
+    config_class : ``lsst.pipe.base.Config``-type
         The configuration class (not an instance) corresponding to a Task.
 
     Returns

--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,10 @@ extras_require = {
     'dev': [
         'wheel>=0.29.0',
         'twine>=1.8.1',
-        'pytest==3.0.4',
-        'pytest-cov==2.4.0',
-        'pytest-flake8==0.8.1',
+        'pytest==4.2.0',
+        'pytest-cov==2.6.1',
+        'pytest-flake8==1.0.4',
         'pytest-mock==1.4.0',
-        'flake8==3.3.0',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?
         'sphinx-click>=1.2.0,<1.3.0',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ extras_require = {
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
         'numpydoc>=0.8.0,<0.9.0',
         'sphinx-automodapi>=0.7,<0.8',
-        'breathe==4.4.0'
+        'breathe==4.4.0',
+        'sphinx-jinja==1.1.0',
     ],
 
     # For documenteer development environments

--- a/tests/test_sphinxconfig_stackconf.py
+++ b/tests/test_sphinxconfig_stackconf.py
@@ -1,0 +1,84 @@
+"""Tests for the documenteer.sphinxconfig.stackconf module.
+"""
+
+from documenteer.sphinxconfig.stackconf import (
+    _insert_eups_version,
+    _insert_single_package_eups_version)
+
+
+def test_eups_version_daily(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('EUPS_TAG', 'd_2019_02_08')
+        import os
+        print(os.getenv('EUPS_TAG'))
+        c = {}
+        c = _insert_eups_version(c)
+
+    assert c['release_eups_tag'] == 'd_2019_02_08'
+    assert c['release_git_ref'] == 'master'
+    assert c['version'] == 'd_2019_02_08'
+    assert c['release'] == 'd_2019_02_08'
+    assert c['scipipe_conda_ref'] == 'master'
+    assert c['pipelines_demo_ref'] == 'master'
+    assert c['newinstall_ref'] == 'master'
+
+
+def test_eups_version_weekly(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('EUPS_TAG', 'w_2019_05')
+        c = {}
+        c = _insert_eups_version(c)
+
+    assert c['release_eups_tag'] == 'w_2019_05'
+    assert c['release_git_ref'] == 'w.2019.05'
+    assert c['version'] == 'w_2019_05'
+    assert c['release'] == 'w_2019_05'
+    assert c['scipipe_conda_ref'] == 'w.2019.05'
+    assert c['pipelines_demo_ref'] == 'w.2019.05'
+    assert c['newinstall_ref'] == 'w.2019.05'
+
+
+def test_eups_version_major(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('EUPS_TAG', 'v17_0')
+        c = {}
+        c = _insert_eups_version(c)
+
+    assert c['release_eups_tag'] == 'v17_0'
+    assert c['release_git_ref'] == '17.0'
+    assert c['version'] == 'v17_0'
+    assert c['release'] == 'v17_0'
+    assert c['scipipe_conda_ref'] == '17.0'
+    assert c['pipelines_demo_ref'] == '17.0'
+    assert c['newinstall_ref'] == '17.0'
+
+
+def test_eups_version_rc(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setenv('EUPS_TAG', 'v17_0_rc1')
+        c = {}
+        c = _insert_eups_version(c)
+
+    assert c['release_eups_tag'] == 'v17_0_rc1'
+    assert c['release_git_ref'] == '17.0.rc1'
+    assert c['version'] == 'v17_0_rc1'
+    assert c['release'] == 'v17_0_rc1'
+    assert c['scipipe_conda_ref'] == '17.0.rc1'
+    assert c['pipelines_demo_ref'] == '17.0.rc1'
+    assert c['newinstall_ref'] == '17.0.rc1'
+
+
+def test_eups_version_single_package(monkeypatch):
+    version_string = 'pkgversion'
+    with monkeypatch.context() as m:
+        m.delenv('EUPS_TAG', raising=False)
+        c = {}
+        c = _insert_single_package_eups_version(c, version_string)
+
+    assert c['release_eups_tag'] == 'current'
+    assert c['release_git_ref'] == 'master'
+    assert c['version'] == version_string
+    assert c['release'] == version_string
+    assert c['scipipe_conda_ref'] == 'master'
+    assert c['pipelines_demo_ref'] == 'master'
+    assert c['newinstall_ref'] == 'master'


### PR DESCRIPTION
From the change log:

- This release adds the `sphinx-jinja`_ extension for ``documenteer[pipelines]`` installations.
  This extension makes it possible to dynamically create content with Jinja templating.

- The ``documenteer.sphinxconfig.stackconf`` module sets up a ``default`` context for the ``jinja`` directive that includes all module attributes in the Sphinx config module.

- The ``documenteer.sphinxconfig.stackconf`` module includes several new configuration attributes that are driven by the presence of an ``EUPS_TAG`` environment variable.
  The overall intent of these variables is to make it possible to render installation documentation for the https://pipelines.lsst.io documentation project from the ``EUPS_TAG`` environment variable.
  The variables are:

  - ``release_eups_tag``
  - ``release_git_ref``
  - ``release``
  - ``version``
  - ``scipipe_conda_env_mac_url``
  - ``scipipe_conda_env_linux_url``
  - ``scipipe_conda_git_ref``

  These variables are accessible from the ``jinja`` directive's context.

- This release also added some new substitutions to the ``rst_epilog`` of stack-based projects:

  - ``|eups-tag|`` --- the current EUPS tag, based on the ``EUPS_TAG`` environment variable.
  - ``|eups-tag-mono|`` --- monospace typeface version of ``|eups-tag|``.
  - ``|eups-tag-bold|`` --- bold typeface version of ``|eups-tag|``.

- Fixed some bugs with the display of copyrights in stack-based projects.
