### PR TITLE
DM-17765: Filter packages by the EUPS table file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- The stack documentation build now requires that packages be explicitly required by the main documentation project's EUPS table file.
+  Before, a package only needed a ``doc/manifest.yaml`` file and to be currently set up in the EUPS environment to be linked into the documentation build.
+  This would lead to packages being included in a documentation build despite not being a part of that stack product.
+
 0.4.5 (2019-02-06)
 ------------------
 

--- a/tests/test_stackdocs_build.py
+++ b/tests/test_stackdocs_build.py
@@ -108,3 +108,18 @@ def test_remove_existing_links(temp_dirname):
     build.remove_existing_links(root_packages_path)
     assert not os.path.exists(os.path.join(root_packages_path,
                                            'package_alpha'))
+
+
+def test_list_packages_in_eups_table():
+    table_text = (
+        "# commented line"
+        "setupRequired(afw)"
+        "setupRequired(display_ds9)"
+        "setupRequired(meas_extensions_photometryKron)"
+    )
+
+    listed_packages = build.list_packages_in_eups_table(table_text)
+    assert 'afw' in listed_packages
+    assert 'display_ds9' in listed_packages
+    assert 'meas_extensions_photometryKron' in listed_packages
+    assert len(listed_packages) == 3


### PR DESCRIPTION
Before, EUPS packages would be incorporated into the stack documentation build if they were set up by EUPS _and_ had a `doc/manifest.yaml` file. Now packages must all be explicitly required (`setupRequired`) by the EUPS table file of the main documentation repository.

This change prevents dependencies of the stack project, which are not actually released with that project, from being automatically incorporated into documentation.