### PR TITLE
DM-17263: Improve single package builds and version 0.5.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,13 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.5.0 (2019-02-11)
+------------------
 
 - The stack documentation build now requires that packages be explicitly required by the main documentation project's EUPS table file.
   Before, a package only needed a ``doc/manifest.yaml`` file and to be currently set up in the EUPS environment to be linked into the documentation build.
   This would lead to packages being included in a documentation build despite not being a part of that stack product.
+  :jirab:`DM-17765`
 
 - This release adds the `sphinx-jinja`_ extension for ``documenteer[pipelines]`` installations.
   This extension makes it possible to dynamically create content with Jinja templating.
@@ -26,6 +27,7 @@ Unreleased
   - ``pipelines_demo_ref``
 
   These variables are accessible from the ``jinja`` directive's context.
+  :jirab:`DM-17065`
 
 - This release also added some new substitutions to the ``rst_epilog`` of stack-based projects:
 
@@ -33,7 +35,18 @@ Unreleased
   - ``|eups-tag-mono|`` --- monospace typeface version of ``|eups-tag|``.
   - ``|eups-tag-bold|`` --- bold typeface version of ``|eups-tag|``.
 
+  The ``|current-release|`` substitution is no longer available.
+
 - Fixed some bugs with the display of copyrights in stack-based projects.
+
+- The project's name is also used as the ``logotext`` at the top of the page for stack-based projects.
+  Previously the ``logotext`` would always be "LSST Science Pipelines."
+  :jirab:`DM-17263`
+
+- Added the following projects to the intersphinx inventory of stack-based projects:
+
+  - ``firefly_client``
+  - ``astro_metadata_translator``
 
 0.4.5 (2019-02-06)
 ------------------

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -59,6 +59,9 @@ def _insert_intersphinx_mapping(c):
         'sklearn': ('https://scikit-learn.org/stable/', None),
         'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
         'astropy': ('http://docs.astropy.org/en/v3.0.x/', None),
+        'astro_metadata_translator': (
+            'https://astro-metadata-translator.lsst.io', None),
+        'firefly_client': ('https://firefly-client.lsst.io', None)
     }
     c['intersphinx_timeout'] = 10.0  # seconds
     c['intersphinx_cache_limit'] = 5  # days

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -78,7 +78,7 @@ def _insert_html_configs(c, *, project_name, short_project_name):
     # Theme options are theme-specific and customize the look and feel of a
     # theme further.  For a list of options available for each theme, see the
     # documentation.
-    c['html_theme_options'] = {}
+    c['html_theme_options'] = {'logotext': short_project_name}
 
     # The name for this set of Sphinx documents.  If None, it defaults to
     # "<project> v<release> documentation".

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -502,7 +502,7 @@ def build_package_configs(project_name,
     if copyright is not None:
         c['copyright'] = copyright
     else:
-        c['copyright'] = '{:s} LSST contributors.'.format(
+        c['copyright'] = '{:s} LSST contributors'.format(
             date.strftime('%Y'))
 
     c['today'] = date.strftime('%Y-%m-%d')


### PR DESCRIPTION
- The logotext for single package builds is now the name of the project configured through the `doc/conf.py` file
- Fix the double full-stop issue on copyrights
- Add `astro_metadata_translator` and `firefly_client` to the intersphinx inventory of pipelines documentation projects.