### PR TITLE
Pin docutils to 0.14

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+0.5.1 (2019-07-22)
+------------------
+
+- Pin docutils temporarily to ``0.14``.
+  The latest release, 0.15, is currently incompatible with the ``:jira:`` role.
+
 0.5.0 (2019-02-11)
 ------------------
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Association of Universities for Research in Astronomy, Inc.
+Copyright (c) 2015-2019 Association of Universities for Research in Astronomy, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Documenteer'
-copyright = '2018 Association of Universities for Research in Astronomy'
+copyright = '2015-2019 Association of Universities for Research in Astronomy'
 author = 'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ long_description = read('README.rst')
 # Core dependencies
 install_requires = [
     'Sphinx>=1.7.0,<1.8.0',
+    'docutils==0.14',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',


### PR DESCRIPTION
docutils 0.15 came out and it breaks the `jira*` roles. Sphinx doesn't strongly pin docutils, so let's pin it through documenteer until the role can be fixed.