### PR TITLE
DM-20767: Add sphinx-argparse 0.2.x for pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 git:
@@ -7,9 +8,10 @@ git:
   depth: false
 matrix:
   include:
-    - python: "3.5"
-    # Use the Python 3.6 build for PyPI deployments and doc uploads
     - python: "3.6"
+      env: PYPI_DEPLOY=false LTD_SKIP_UPLOAD=true
+    # Use the Python 3.7 build for PyPI deployments and doc uploads
+    - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false
 install:
   - "pip install -e .[dev]"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Add `sphinxcontrib.autoprogram <https://sphinxcontrib-autoprogram.readthedocs.io/en/stable/>`_ to enable automated reference documentation of argparse-based command-line scripts.
+  This extension is available with the ``documenteer[pipelines]`` installation extra and enabled by default for LSST Science Pipelines projects.
+  :jira:`20767`
+
+- Update the official list of tested and supported Python versions to Python 3.6 and 3.7.
+
 0.5.1 (2019-07-22)
 ------------------
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -32,6 +32,7 @@ def _insert_extensions(c):
         'sphinx.ext.ifconfig',
         'sphinxcontrib.jinja',
         'sphinx-prompt',
+        'sphinxcontrib.autoprogram',
         'numpydoc',
         'sphinx_automodapi.automodapi',
         'sphinx_automodapi.smart_resolver',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ extras_require = {
         'sphinx-automodapi>=0.7,<0.8',
         'breathe==4.4.0',
         'sphinx-jinja==1.1.0',
+        'sphinxcontrib-autoprogram>=0.1.5,<0.2.0',
     ],
 
     # For documenteer development environments

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ url = 'https://github.com/lsst-sqre/documenteer'
 classifiers = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
 ]
 keywords = 'sphinx documentation lsst'
 


### PR DESCRIPTION
This lets us use the `argparse` directive from [sphinx-argparse](https://github.com/ribozz/sphinx-argparse) in pipelines documentation to autodocument ad hoc scripts.