### PR TITLE
Fix to run with docutils 0.15.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Fixed compatibility with docutils 0.15.
+  Now Sphinx will control which version of docutils is used, which should now be 0.15.
+
 0.5.2 (2019-08-01)
 ------------------
 

--- a/documenteer/sphinxext/jira.py
+++ b/documenteer/sphinxext/jira.py
@@ -97,8 +97,8 @@ def jira_bracket_role(name, rawtext, text, lineno, inliner,
     """
     node_list, _ = jira_role(name, rawtext, text, lineno, inliner,
                              options=options, content=None, oxford_comma=False)
-    node_list = nodes.raw(text=open_symbol, format='html') \
-        + node_list + nodes.raw(text=close_symbol, format='html')
+    node_list.insert(0, nodes.raw(text=open_symbol, format='html'))
+    node_list.append(nodes.raw(text=close_symbol, format='html'))
     return node_list, []
 
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ long_description = read('README.rst')
 # Core dependencies
 install_requires = [
     'Sphinx>=1.7.0,<1.8.0',
-    'docutils==0.14',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',


### PR DESCRIPTION
Understanding that docutils 0.15 [isn't supported](https://github.com/lsst-sqre/documenteer/blob/03f21ce02a1fb2e15b8a186ce299380c345b36eb/setup.py#L34)... I found I had to make this change to make it work. I hope it's useful.