### PR TITLE
DM-20850: Enable index generation for Pipelines documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,18 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.5.3 (2019-08-07)
+------------------
+
+- Enabled the ``html_use_index`` and ``html_domain_indices`` configurations for Stack documentation projects to enable automatic index generation.
+  The ``genindex`` contains links to all command-line options and Python objects (Sphinx's domains).
+  This also opens us up to a more general content index by way of the `index directive <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#index-generating-markup>`_.
+  :jira:`20850`
 
 - Fixed compatibility with docutils 0.15.
   Now Sphinx will control which version of docutils is used, which should now be 0.15.
+
+- Also updated the intersphinx URL for Pandas to use https.
 
 0.5.2 (2019-08-01)
 ------------------

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -58,7 +58,7 @@ def _insert_intersphinx_mapping(c):
         'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
         'matplotlib': ('https://matplotlib.org/', None),
         'sklearn': ('https://scikit-learn.org/stable/', None),
-        'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
+        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
         'astropy': ('http://docs.astropy.org/en/v3.0.x/', None),
         'astro_metadata_translator': (
             'https://astro-metadata-translator.lsst.io', None),

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -126,10 +126,10 @@ def _insert_html_configs(c, *, project_name, short_project_name):
     c['html_use_smartypants'] = True
 
     # If false, no module index is generated.
-    c['html_domain_indices'] = False
+    c['html_domain_indices'] = True
 
     # If false, no index is generated.
-    c['html_use_index'] = False
+    c['html_use_index'] = True
 
     # If true, the index is split into individual pages for each letter.
     c['html_split_index'] = False


### PR DESCRIPTION
- Enabled the `html_use_index` and `html_domain_indices` configurations for Stack documentation projects to enable automatic index generation. The `genindex` contains links to all command-line options and Python objects (Sphinx's domains). This also opens us up to a more general content index by way of the [index directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=index#index-generating-markup).
- Also updated the intersphinx URL for Pandas to use https.