### PR TITLE
DM-20839: Update lsst-dd-rtd-theme to 0.2.2 (0.5.4 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.5.4 (2019-11-03)
+------------------
+
+- This new version of the technote sphinx theme should fix the edition link in the sidebar for non-main editions. :jirab:`20839`
+
 0.5.3 (2019-08-07)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
 extras_require = {
     # For technical note Sphinx projects
     'technote': [
-        'lsst-dd-rtd-theme==0.2.1',
+        'lsst-dd-rtd-theme==0.2.2',
         # 0.4.1 is incompatible with Sphinx <1.8.0. Unpin once we upgrade
         # Sphinx.
         'sphinxcontrib-bibtex==0.4.0'


### PR DESCRIPTION
This new version of the technote sphinx theme should fix the edition link in the sidebar for non-main editions.