### PR TITLE
DM-20839: Update lsst-dd-rtd-theme for 0.2.2 (0.4.6 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+0.4.6 (2019-11-03)
+------------------
+
+- This new version of the technote sphinx theme should fix the edition link in the sidebar for non-main editions. :jirab:`DM-20839`
+- Fixed compatibility with docutils 0.15. (backported from 0.5.3).
+
 0.4.5 (2019-02-06)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,7 @@ default_role = 'py:obj'
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'requests': ('http://docs.python-requests.org/en/v2.9.1/', None),
+    'requests': ('http://3.python-requests.org', None),
     'developer': ('https://developer.lsst.io/', None),
     'pybtex': ('https://docs.pybtex.org/', None),
     'sphinx': ('http://www.sphinx-doc.org/en/master/', None),

--- a/documenteer/sphinxext/jira.py
+++ b/documenteer/sphinxext/jira.py
@@ -97,8 +97,8 @@ def jira_bracket_role(name, rawtext, text, lineno, inliner,
     """
     node_list, _ = jira_role(name, rawtext, text, lineno, inliner,
                              options=options, content=None, oxford_comma=False)
-    node_list = nodes.raw(text=open_symbol, format='html') \
-        + node_list + nodes.raw(text=close_symbol, format='html')
+    node_list.insert(0, nodes.raw(text=open_symbol, format='html'))
+    node_list.append(nodes.raw(text=close_symbol, format='html'))
     return node_list, []
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
 extras_require = {
     # For technical note Sphinx projects
     'technote': [
-        'lsst-dd-rtd-theme==0.2.1',
+        'lsst-dd-rtd-theme==0.2.2',
         # 0.4.1 is incompatible with Sphinx <1.8.0. Unpin once we upgrade
         # Sphinx.
         'sphinxcontrib-bibtex==0.4.0'


### PR DESCRIPTION
This new version of the technote sphinx theme should fix the edition link in the sidebar for non-main editions.