### PR TITLE
DM-22533: Compatibility with Sphinx 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ git:
   depth: false
 matrix:
   include:
-    - python: "3.6"
-      env: PYPI_DEPLOY=false LTD_SKIP_UPLOAD=true
     # Use the Python 3.7 build for PyPI deployments and doc uploads
     - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,23 @@ Change Log
 0.6.0 (unreleased)
 ------------------
 
+- Documenteer now works with Sphinx 2.0+.
+  By default, Documenteer will install the latest version of Sphinx for you.
+  Other dependency upgrades:
+
+  - The ``click`` version now floats.
+  - ``numpydoc`` is pinned at 0.8.0.
+  - ``sphinx-automodapi`` is pinned at 0.12.
+  - ``breathe`` is pinned at 4.14.0.
+
+  Updates to development or test dependencies:
+
+  - pytest is pinned to 4.5.0 (to match the pytest used by the ``lsst_distrib`` stack).
+  - sphinx-click is pinned to 2.3.1.
+
+- Python 3.6 is no longer officially supported.
+  Documenteer is tested with Python 3.7.
+
 - New Sphinx configuration facilities should prevent recursion issues by more cleanly populating the Python attributes in the configuration module:
 
   - Technote projects now import ``documenteer.conf.technote`` in their ``conf.py`` files.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'sphinx-prompt',
     'GitPython',
     'requests',
-    'click>=6.7,<7.0'
+    'click'
 ]
 
 # Project-specific dependencies

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ url = 'https://github.com/lsst-sqre/documenteer'
 classifiers = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
 ]
 keywords = 'sphinx documentation lsst'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
     # For the pipelines.lsst.io documentation project
     'pipelines': [
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
-        'numpydoc==0.9.1',
+        'numpydoc==0.8.0',
         'sphinx-automodapi==0.12',
         'breathe==4.14.0',
         'sphinx-jinja==1.1.0',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
     'dev': [
         'wheel>=0.29.0',
         'twine>=1.8.1',
-        'pytest==4.2.0',
+        'pytest==4.5.0',
         'pytest-cov==2.6.1',
         'pytest-flake8==1.0.4',
         'pytest-mock==1.4.0',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'Sphinx>=1.7.0,<1.8.0',
+    'Sphinx>=2.0.0',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',
@@ -43,17 +43,15 @@ extras_require = {
     # For technical note Sphinx projects
     'technote': [
         'lsst-dd-rtd-theme==0.2.2',
-        # 0.4.1 is incompatible with Sphinx <1.8.0. Unpin once we upgrade
-        # Sphinx.
-        'sphinxcontrib-bibtex==0.4.0'
+        'sphinxcontrib-bibtex==1.0.0'
     ],
 
     # For the pipelines.lsst.io documentation project
     'pipelines': [
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
-        'numpydoc>=0.8.0,<0.9.0',
-        'sphinx-automodapi>=0.7,<0.8',
-        'breathe==4.4.0',
+        'numpydoc==0.9.1',
+        'sphinx-automodapi==0.12',
+        'breathe==4.14.0',
         'sphinx-jinja==1.1.0',
         'sphinxcontrib-autoprogram>=0.1.5,<0.2.0',
     ],
@@ -68,7 +66,7 @@ extras_require = {
         'pytest-mock==1.4.0',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?
-        'sphinx-click>=1.2.0,<1.3.0',
+        'sphinx-click==2.3.1',
     ],
 }
 # Add project dependencies to the dev dependencies


### PR DESCRIPTION
The goal of this work is to bring documenteer and LSST's Sphinx documentation stack up to date with Sphinx 2.x.

Fixes #47 

- Documenteer now works with Sphinx 2.0+.
  By default, Documenteer will install the latest version of Sphinx for you.
  Other dependency upgrades:

  - The ``click`` version now floats.
  - ``numpydoc`` is pinned at 0.8.0.
  - ``sphinx-automodapi`` is pinned at 0.12.
  - ``breathe`` is pinned at 4.14.0.

  Updates to development or test dependencies:

  - pytest is pinned to 4.5.0.
  - sphinx-click is pinned to 2.3.1.

- Python 3.6 is no longer officially supported.
  Documenteer is tested with Python 3.7.