### PR TITLE
DM-22537: Use yaml.safe_load (0.4.7 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.4.7 (2019-12-09)
+------------------
+
+- Technote configuration now uses ``yaml.safe_load`` instead of ``yaml.load``.
+  See the `pyyaml docs for details <https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation>`__.
+  Backported from 0.5.5.
+  :jirab:`DM-22537`
+
 0.4.6 (2019-11-03)
 ------------------
 

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -62,7 +62,7 @@ def configure_technote(meta_stream):
         Dictionary of configurations that should be added to the ``conf.py``
         global namespace.
     """
-    _metadata = yaml.load(meta_stream)
+    _metadata = yaml.safe_load(meta_stream)
     confs = _build_confs(_metadata)
     return confs
 


### PR DESCRIPTION
Technote configuration now uses ``yaml.safe_load`` instead of ``yaml.load``. See the [pyyaml docs for details](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation).

See #73 for the mainline PR.

Closes #63 