### PR TITLE
DM-22500: Attempt to use exhale for C++ docs for Pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ git:
   depth: false
 matrix:
   include:
-    - python: "3.6"
-      env: PYPI_DEPLOY=false LTD_SKIP_UPLOAD=true
     # Use the Python 3.7 build for PyPI deployments and doc uploads
     - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -1,0 +1,359 @@
+"""Sphinx configuration for lsst/pipelines_lsst_io (pipelines.lsst.io).
+
+To use this configuration in a Sphinx project, write a conf.py::
+
+    from documenteer.conf.pipelines import *
+
+This configuration is broken down into these sections:
+
+#EXT
+    Sphinx extensions
+#SPHINX
+    Core Sphinx configurations
+#INTER
+    Intersphinx configuration
+#HTML
+    HTML builder and theme configuration
+#AUTOMODAPI
+    automodapi and autodoc configuration
+#GRAPHVIZ
+    graphviz configuration
+#MATPLOTLIB
+    matplotlib extension configuration
+#TODO
+    todo extension configuration
+#EUPS
+    Compute EUPS tag and versioning information
+#JINJA
+    Jinja extension configuration
+#EPILOG
+    rst_epilog is reStructured text content present on every page
+#CLEANUP
+    Cleaning up the namespace for conf.py
+"""
+
+import datetime
+import os
+import warnings
+
+import lsst_sphinx_bootstrap_theme
+
+
+# ============================================================================
+# #EXT Sphinx extensions
+# ============================================================================
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinxcontrib.jinja',
+    'sphinx-prompt',
+    'sphinxcontrib.autoprogram',
+    'numpydoc',
+    'sphinx_automodapi.automodapi',
+    'sphinx_automodapi.smart_resolver',
+    'breathe',
+    'documenteer.sphinxext',
+    'documenteer.sphinxext.lssttasks'
+]
+
+# ============================================================================
+# #SPHINX Core Sphinx configurations
+# ============================================================================
+project = 'LSST Science Pipelines'
+
+_date = datetime.datetime.now()
+
+today = _date.strftime('%Y-%m-%d')
+
+# Use this copyright for now. Ultimately we want to gather COPYRIGHT files
+# and build an integrated copyright that way.
+copyright = f'2015-{_date.year} LSST contributors'
+
+del _date
+
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+source_suffix = '.rst'
+
+# The encoding of source files.
+source_encoding = 'utf-8'
+
+# The master toctree document.
+master_doc = 'index'
+
+# Configure figure numbering
+numfig = True
+numfig_format = {
+    'figure': 'Figure %s',
+    'table': 'Table %s',
+    'code-block': 'Listing %s'
+}
+
+# The reST default role (used for this markup: `text`)
+default_role = 'obj'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = [
+    'README.rst',
+    # Build products
+    '_build',
+    # Source for release notes (contents are included in built pages)
+    'releases/note-source/*.rst',
+    'releases/tickets-source/*.rst',
+    # EUPS configuration directory
+    'ups',
+    # Recommended directory for pip installing doc eng Python packages
+    '.pyvenv',
+    # GitHub templates
+    '.github',
+    # This 'home' directory is created by the docubase image for the
+    # sqre/infra/documenteer ci.lsst.codes Jenkins job. Ideally this
+    # shouldn't be in the directory at all, but we certainly need to
+    # ignore it while its here.
+    'home',
+]
+
+# ============================================================================
+# #INTER Intersphinx configuration
+# ============================================================================
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'matplotlib': ('https://matplotlib.org/', None),
+    'sklearn': ('https://scikit-learn.org/stable/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'astropy': ('http://docs.astropy.org/en/v3.0.x/', None),
+    'astro_metadata_translator': (
+        'https://astro-metadata-translator.lsst.io', None),
+    'firefly_client': ('https://firefly-client.lsst.io', None)
+}
+intersphinx_timeout = 10.0  # seconds
+intersphinx_cache_limit = 5  # days
+
+
+# ============================================================================
+# #HTML HTML builder and theme configuration
+# ============================================================================
+
+# Use the lsst-sphinx-bootstrap-theme
+templates_path = [
+    '_templates',
+    lsst_sphinx_bootstrap_theme.get_html_templates_path()]
+html_theme = 'lsst_sphinx_bootstrap_theme'
+html_theme_path = [lsst_sphinx_bootstrap_theme.get_html_theme_path()]
+
+# Theme options are theme-specific and customize the look and feel of a
+# theme further.  For a list of options available for each theme, see the
+# documentation.
+html_theme_options = {
+    'logotext': project
+}
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = project
+
+# A shorter title for the navigation bar.  Default is the same as
+# html_title.
+html_short_title = project
+
+# The name of an image file (relative to this directory) to place at the
+# top of the sidebar.
+html_logo = None
+
+# The name of an image file (within the static path) to use as favicon of
+# the docs.  This file should be a Windows icon file (.ico) being 16x16 or
+# 32x32 pixels large.
+html_favicon = None
+
+# Add any paths that contain custom static files (such as style sheets)
+# here, relative to this directory. They are copied after the builtin
+# static files, so a file named "default.css" will overwrite the builtin
+# "default.css".
+if os.path.isdir('_static'):
+    html_static_path = ['_static']
+else:
+    # If a project does not have a _static/ directory, don't list it
+    # so that there isn't a warning.
+    html_static_path = []
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+# html_extra_path = []
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page
+# bottom, using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+html_use_smartypants = True
+
+# If false, no module index is generated.
+html_domain_indices = True
+
+# If false, no index is generated.
+html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+html_split_index = False
+
+# If true, links to the reST sources are added to the pages.
+html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is
+# True.
+html_show_sphinx = True
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is
+# True.
+html_show_copyright = True
+
+# If true, an OpenSearch description file will be output, and all pages
+# will contain a <link> tag referring to it.  The value of this option must
+# be the base URL from which the finished HTML is served.
+# html_use_opensearch = ''
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+html_file_suffix = '.html'
+
+# Language to be used for generating the HTML full-text search index.
+html_search_language = 'en'
+
+
+# ============================================================================
+# #AUTOMODAPI automodapi and autodoc configuration
+# ============================================================================
+# Don't show summaries of the members in each class along with the
+# class' docstring
+numpydoc_show_class_members = False
+
+autosummary_generate = True
+
+automodapi_toctreedirnm = 'py-api'
+automodsumm_inherited_members = True
+
+# Docstrings for classes and methods are inherited from parents.
+autodoc_inherit_docstrings = True
+
+# Class documentation should only contain the class docstring and
+# ignore the __init__ docstring, account to LSST coding standards.
+# c['autoclass_content'] = "both"
+autoclass_content = "class"
+
+# Default flags for automodapi directives. Special members are dunder
+# methods.
+# NOTE: We want to used `inherited-members`, but it seems to be causing
+# documentation duplication in the automodapi listings. We're leaving
+# this out for now. See https://jira.lsstcorp.org/browse/DM-14782 for
+# additional notes.
+# NOTE: Without inherited members set, special-members doesn't need seem
+# to have an effect (even for special members where the docstrings are
+# directly written in the class, not inherited.
+# autodoc_default_flags = ['inherited-members']
+autodoc_default_flags = [
+    'show-inheritance',
+    'special-members'
+]
+
+# ============================================================================
+# #GRAPHVIZ graphviz configuration
+# graphviz is primarily used by automodapi to create inheritance diagrams.
+# ============================================================================
+# Render inheritance diagrams in SVG
+graphviz_output_format = "svg"
+
+graphviz_dot_args = [
+    '-Nfontsize=10',
+    '-Nfontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Efontsize=10',
+    '-Efontname=Helvetica Neue, Helvetica, Arial, sans-serif',
+    '-Gfontsize=10',
+    '-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif'
+]
+
+# ============================================================================
+# #MATPLOTLIB matplotlib extension configuration
+# ============================================================================
+try:
+    import matplotlib.sphinxext.plot_directive
+    extensions += [matplotlib.sphinxext.plot_directive.__name__]
+    del matplotlib.sphinxext.plot_directive
+except (ImportError, AttributeError):
+    # AttributeError is checked here in case matplotlib is installed but
+    # Sphinx isn't.  Note that this module is imported by the config file
+    # generator, even if we're not building the docs.
+    warnings.warn(
+        "matplotlib's plot_directive could not be imported. "
+        "Inline plots will not be included in the output.")
+
+# ============================================================================
+# #TODO todo extension configuration
+# ============================================================================
+# Hide todo directives in the "published" documentation on the main site.
+todo_include_todos = False
+
+# ============================================================================
+# #EUPS
+# Compute information about the EUPS tag and versioning
+# This info will get exposed through the Jinja configuration and the rst prolog
+# ============================================================================
+# Attempt to get the EUPS tag from the build environment
+eups_tag = os.getenv('EUPS_TAG', 'd_latest')
+
+# Try to guess the Git ref that corresponds to this tag
+if eups_tag in ('d_latest', 'w_latest', 'current'):
+    git_ref = 'master'
+elif eups_tag.startswith('d_'):
+    # Daily EUPS tags are not tagged on git
+    git_ref = 'master'
+elif eups_tag.startswith('v'):
+    # Major version or release candidate tag
+    git_ref = eups_tag.lstrip('v').replace('_', '.')
+elif eups_tag.startswith('w_'):
+    # Regular weekly tag
+    git_ref = eups_tag.replace('_', '.')
+else:
+    # Ideally shouldn't get to this point
+    git_ref = 'master'
+
+# ============================================================================
+# #JINJA jinja extension configuration
+# ============================================================================
+jinja_contexts = {
+    'default': {
+        'release_eups_tag': eups_tag,
+        'release_git_ref': git_ref,
+        'pipelines_demo_ref': git_ref,
+        'scipipe_conda_ref': git_ref,
+        'newinstall_ref': git_ref,
+    }
+}
+
+# ============================================================================
+# rst_epilog is reStructured text content present on every page
+# ============================================================================
+rst_epilog = f"""
+
+.. |eups-tag| replace:: {eups_tag}
+.. |eups-tag-mono| replace:: ``{eups_tag}``
+.. |eups-tag-bold| replace:: **{eups_tag}**
+"""
+
+# ============================================================================
+# #CLEANUP
+# Remove imports from namespace
+# This is designed to improve the pickleability of conf.py files
+# ============================================================================
+del datetime
+del os
+del warnings
+del lsst_sphinx_bootstrap_theme

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -56,9 +56,10 @@ extensions = [
     'numpydoc',
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
-    'breathe',
     'documenteer.sphinxext',
-    'documenteer.sphinxext.lssttasks'
+    'documenteer.sphinxext.lssttasks',
+    'breathe',
+    'exhale',
 ]
 
 # ============================================================================

--- a/documenteer/conf/pipelinespkg.py
+++ b/documenteer/conf/pipelinespkg.py
@@ -1,0 +1,39 @@
+"""Sphinx configuration for a single-package documentation builds for packages
+in pipelines.lsst.io.
+
+These configurations build upon `documenteer.conf.pipelines`.
+
+To use this configuration, projects need to import this module's contents
+into their Sphinx :file:`conf.py` and override configuration related to the
+project's name:
+
+.. code-block:: python
+
+   from documenteer.conf.pipelinespkg import *
+
+
+   project = "example"
+   html_theme_options['logotext'] = project
+   html_title = project
+   html_short_title = project
+
+Replace "example" with the name of the current package.
+
+You can set, or override, additional Sphinx configurations after the
+``documenteer`` import in your Sphinx :file:`conf.py` file.
+
+.. note::
+
+   This configuration is only used for single-package builds.
+   It doesn't affect the pipelines.lsst.io build.
+"""
+
+# Derive configuration from the full-stack documentation build
+from .pipelines import *  # noqa: F401 F403
+
+
+# ============================================================================
+# todo extension configuration
+# ============================================================================
+# Show todo directives in the development documentation for single packages.
+todo_include_todos = True

--- a/documenteer/conf/technote.py
+++ b/documenteer/conf/technote.py
@@ -1,0 +1,299 @@
+"""Sphinx configuration for LSST technotes.
+
+To use this configuration in a Sphinx technote project, write a conf.py
+containing::
+
+    from documenteer.conf.technote import *
+
+This configuration is broken down into these sections:
+
+#METADATA
+    Configurations based on metadata.yaml
+#EXT
+    Sphinx extensions
+#SPHINX
+    Core Sphinx configurations
+#HTML
+    HTML builder and theme configuration
+#TODO
+    todo extension configuration
+#MATHJAX
+    MathJax extension configuration
+#INTER
+    Intersphinx configuration
+"""
+
+# Ordered as they are declared in this module
+__all__ = (
+    # METADATA
+    'project',
+    'authors',
+    'copyright',
+    'exclude_patterns',
+    'version',
+    'release',
+    'today',
+    'html_context',
+    # EXT
+    'extensions',
+    # SPHINX
+    'source_suffix',
+    'source_encoding',
+    'master_doc',
+    'numfig',
+    'numfig_format',
+    # HTML
+    'templates_path',
+    'html_theme',
+    'html_theme_path',
+    'html_theme_options',
+    'html_title',
+    'html_short_title',
+    'html_logo',
+    'html_favicon',
+    'html_static_path',
+    'html_extra_path',
+    'html_last_updated_fmt',
+    'html_use_smartypants',
+    'html_domain_indices',
+    'html_use_index',
+    'html_split_index',
+    'html_show_sourcelink',
+    'html_show_sphinx',
+    'html_file_suffix',
+    'html_search_language',
+    # TODO
+    'todo_include_todos',
+    # MATHJAX
+    'mathjax_path',
+    # INTER
+    'intersphinx_mapping',
+    'intersphinx_timeout',
+    'intersphinx_cache_limit',
+)
+
+import datetime
+from pathlib import Path
+
+import lsst_dd_rtd_theme
+import yaml
+
+from ..sphinxconfig.utils import (
+    read_git_branch,
+    get_project_content_commit_date)
+
+# ============================================================================
+# #METADATA Configurations based on metadata.yaml
+# ============================================================================
+
+_metadata_path = Path('metadata.yaml')
+try:
+    with _metadata_path.open() as fp:
+        _metadata = yaml.safe_load(fp)
+except OSError:
+    raise OSError(
+        "Technotes require a metadata.yaml file for configuration, but one"
+        "couldn't be opened. See the technote template at "
+        "https://github.com/lsst/templates/tree/master/project_templates/"
+        "technote_rst"
+    )
+
+project = f'{_metadata["doc_id"]}: {_metadata["doc_title"]}'
+
+# FIXME Ideally we want to use an oxford comma here.
+authors = ', '.join(_metadata['authors'])
+
+copyright = _metadata['copyright']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = _metadata.get(
+    'exclude_patterns',
+    ['_build', 'README.rst']
+)
+
+try:
+    version = read_git_branch()
+    _git_branch = version
+except Exception as e:
+    print('Caught exception: {}'.format(e))
+    print('Cannot get Git branch information.')
+    # defaults
+    version = 'Unknown'
+    _git_branch = 'master'
+
+# Override version with metadata.yaml
+if 'version' in _metadata:
+    version = _metadata['version']
+
+# The edit_url is used for "Edit on GitHub" functionality
+if 'github_url' in _metadata:
+    _github_url = _metadata['github_url']
+    if not _github_url.endswith('/'):
+        _github_url = _github_url + '/'
+    _edit_url = '{_github_url}blob/{_git_branch}/index.rst'
+else:
+    _github_url = None
+    _edit_url = None
+
+# The full version, including alpha/beta/rc tags.
+if 'dev_version_suffix' in _metadata:
+    release = "{version}{_metadata['dev_version_suffix']}"
+else:
+    release = version
+
+if 'last_revised' in _metadata:
+    _date = datetime.datetime.strptime(_metadata['last_revised'], '%Y-%m-%d')
+else:
+    # obain date from Git commit at most recent content commit since HEAD
+    try:
+        _date = get_project_content_commit_date(
+            exclusions=exclude_patterns)
+    except Exception as e:
+        print('Caught exception: {}'.format(e))
+        print('Cannot get project content git commit date.')
+        _date = datetime.datetime.now()
+today = _date.strftime('%Y-%m-%d')
+
+# This is available to Jinja2 templates
+html_context = {
+    'author_list': _metadata['authors'],
+    'doc_id': _metadata['doc_id'],
+    'doc_title': _metadata['doc_title'],
+    'last_revised': today,
+    'git_branch': _git_branch,
+    'github_url': _github_url,
+    'edit_url': _edit_url
+}
+
+# ============================================================================
+# #EXT Sphinx extensions
+# ============================================================================
+extensions = [
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx-prompt',
+    'sphinxcontrib.bibtex',
+    'documenteer.sphinxext',
+    'documenteer.sphinxext.bibtex'
+]
+
+# ============================================================================
+# #SPHINX Core Sphinx configurations
+# ============================================================================
+# The suffix(es) of source filenames.
+# You can specify multiple suffix as a list of string:
+source_suffix = '.rst'
+
+# The encoding of source files.
+source_encoding = 'utf-8'
+
+# The master toctree document.
+master_doc = 'index'
+
+numfig = True
+numfig_format = {
+    'figure': 'Figure %s',
+    'table': 'Table %s',
+    'code-block': 'Listing %s'
+}
+
+# ============================================================================
+# #HTML HTML builder and theme configuration
+# ============================================================================
+templates_path = ['_templates']
+html_theme = 'lsst_dd_rtd_theme'
+html_theme_path = [lsst_dd_rtd_theme.get_html_theme_path()]
+
+# Theme options are theme-specific and customize the look and feel of a
+# theme further.  For a list of options available for each theme, see the
+# documentation.
+html_theme_options = {}
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = project
+
+# A shorter title for the navigation bar.  Default is the same as
+# html_title.
+html_short_title = _metadata['doc_id']
+
+# The name of an image file (relative to this directory) to place at the
+# top of the sidebar.
+html_logo = None
+
+# The name of an image file (within the static path) to use as favicon of
+# the docs.  This file should be a Windows icon file (.ico) being 16x16 or
+# 32x32 pixels large.
+html_favicon = None
+
+# Add any paths that contain custom static files (such as style sheets)
+# here, relative to this directory. They are copied after the builtin
+# static files, so a file named "default.css" will overwrite the builtin
+# "default.css".
+if Path('_static').is_dir():
+    html_static_path = ['_static']
+else:
+    # If a project does not have a _static/ directory, don't list it
+    # so that there isn't a warning.
+    html_static_path = []
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+html_extra_path = []
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page
+# bottom, using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+html_use_smartypants = True
+
+# If false, no module index is generated.
+html_domain_indices = False
+
+# If false, no index is generated.
+html_use_index = False
+
+# If true, the index is split into individual pages for each letter.
+html_split_index = False
+
+# If true, links to the reST sources are added to the pages.
+html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+html_show_sphinx = True
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+html_show_copyright = True
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+html_file_suffix = '.html'
+
+# Language to be used for generating the HTML full-text search index.
+html_search_language = 'en'
+
+# ============================================================================
+# #TODO todo extension configuration
+# ============================================================================
+todo_include_todos = True
+
+# ============================================================================
+# #MATHJAX MathJax extension configuration
+# ============================================================================
+# FIXME update this in light of the MathJax CDN deprecation
+mathjax_path = (
+    'https://cdn.mathjax.org/mathjax/latest/'
+    'MathJax.js?config=default'
+)
+
+# ============================================================================
+# #INTER Intersphinx configuration
+# ============================================================================
+intersphinx_mapping = {}
+intersphinx_timeout = 10.0  # seconds
+intersphinx_cache_limit = 5  # days

--- a/documenteer/conf/technote.py
+++ b/documenteer/conf/technote.py
@@ -285,9 +285,9 @@ todo_include_todos = True
 # ============================================================================
 # #MATHJAX MathJax extension configuration
 # ============================================================================
-# FIXME update this in light of the MathJax CDN deprecation
+# http://docs.mathjax.org/en/v2.7-latest/start.html#using-a-content-delivery-network-cdn
 mathjax_path = (
-    'https://cdn.mathjax.org/mathjax/latest/'
+    'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/'
     'MathJax.js?config=default'
 )
 

--- a/documenteer/stackdocs/build.py
+++ b/documenteer/stackdocs/build.py
@@ -276,6 +276,12 @@ def find_package_docs(package_dir, skippedNames=None):
           the static documentation directory in the package. If there
           isn't a declared ``_static`` directory, this dictionary is empty.
 
+        - ``doxygen_index_xml_path`` (`str`). Path of the doxygen index.xml
+          file for a package. None if one doesn't exist.
+
+        - ``doxygen_xml_paths`` (`list` of `str`). List of paths to individual
+          Doxygen XML files, other than ``index.xml``.
+
     Raises
     ------
     NoPackageDocs
@@ -389,10 +395,32 @@ def find_package_docs(package_dir, skippedNames=None):
             static_dirs[relative_static_dir] = full_static_dir
             logger.debug('Found _static doc dir: {0}'.format(full_static_dir))
 
-    Dirs = namedtuple('Dirs', ['module_dirs', 'package_dirs', 'static_dirs'])
+    xml_dir = os.path.join(doc_dir, 'xml')
+
+    doxygen_index_xml_path = os.path.join(xml_dir, 'index.xml')
+    if os.path.exists(doxygen_index_xml_path):
+        logger.debug('Found Doxygen index.xml: %s', doxygen_index_xml_path)
+        doxygen_xml_paths = []
+        with os.scandir(xml_dir) as it:
+            for entry in it:
+                if entry.name != 'index.xml':
+                    doxygen_xml_paths.append(
+                        os.path.join(xml_dir, entry.name)
+                    )
+    else:
+        doxygen_index_xml_path = None
+        doxygen_xml_paths = []
+
+    Dirs = namedtuple(
+        'Dirs',
+        ['module_dirs', 'package_dirs', 'static_dirs',
+         'doxygen_index_xml_path', 'doxygen_xml_paths']
+    )
     return Dirs(module_dirs=module_dirs,
                 package_dirs=package_dirs,
-                static_dirs=static_dirs)
+                static_dirs=static_dirs,
+                doxygen_index_xml_path=doxygen_index_xml_path,
+                doxygen_xml_paths=doxygen_xml_paths)
 
 
 class NoPackageDocs(Exception):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'sphinx-prompt',
     'GitPython',
     'requests',
-    'click>=6.7,<7.0'
+    'click'
 ]
 
 # Project-specific dependencies

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ url = 'https://github.com/lsst-sqre/documenteer'
 classifiers = [
     'Development Status :: 4 - Beta',
     'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
 ]
 keywords = 'sphinx documentation lsst'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
     # For the pipelines.lsst.io documentation project
     'pipelines': [
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
-        'numpydoc==0.9.1',
+        'numpydoc==0.8.0',
         'sphinx-automodapi==0.12',
         'breathe==4.14.0',
         'sphinx-jinja==1.1.0',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
     'dev': [
         'wheel>=0.29.0',
         'twine>=1.8.1',
-        'pytest==4.2.0',
+        'pytest==4.5.0',
         'pytest-cov==2.6.1',
         'pytest-flake8==1.0.4',
         'pytest-mock==1.4.0',

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ extras_require = {
         'breathe==4.14.0',
         'sphinx-jinja==1.1.0',
         'sphinxcontrib-autoprogram>=0.1.5,<0.2.0',
+        'exhale==0.2.3',
     ],
 
     # For documenteer development environments

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ extras_require = {
         'sphinx-jinja==1.1.0',
         'sphinxcontrib-autoprogram>=0.1.5,<0.2.0',
         'exhale==0.2.3',
+        'lxml==4.4.2',
     ],
 
     # For documenteer development environments

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'Sphinx>=1.7.0,<1.8.0',
+    'Sphinx>=2.0.0',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',
@@ -43,17 +43,15 @@ extras_require = {
     # For technical note Sphinx projects
     'technote': [
         'lsst-dd-rtd-theme==0.2.2',
-        # 0.4.1 is incompatible with Sphinx <1.8.0. Unpin once we upgrade
-        # Sphinx.
-        'sphinxcontrib-bibtex==0.4.0'
+        'sphinxcontrib-bibtex==1.0.0'
     ],
 
     # For the pipelines.lsst.io documentation project
     'pipelines': [
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
-        'numpydoc>=0.8.0,<0.9.0',
-        'sphinx-automodapi>=0.7,<0.8',
-        'breathe==4.4.0',
+        'numpydoc==0.9.1',
+        'sphinx-automodapi==0.12',
+        'breathe==4.14.0',
         'sphinx-jinja==1.1.0',
         'sphinxcontrib-autoprogram>=0.1.5,<0.2.0',
     ],
@@ -68,7 +66,7 @@ extras_require = {
         'pytest-mock==1.4.0',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?
-        'sphinx-click>=1.2.0,<1.3.0',
+        'sphinx-click==2.3.1',
     ],
 }
 # Add project dependencies to the dev dependencies


### PR DESCRIPTION
This investigation is to see if [exhale](https://exhale.readthedocs.io) can be used to generate C++ API docs for the while `lsst` namespace and its contents.

I don't think this route will ultimately work because Doxygen needs to document files in order to document `enums` and `defines` (https://exhale.readthedocs.io/en/latest/mastering_doxygen.html#document-your-files-son)