### PR TITLE
DM-22717: Add mypy type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ nosetests.xml
 coverage.xml
 *,cover
 pytest_session.txt
+.mypy_cache
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,30 @@ git:
   depth: false
 matrix:
   include:
-    # Use the Python 3.7 build for PyPI deployments and doc uploads
+    # Use the Python 3.7 build with latest Sphinx for PyPI deployments and doc
+    # uploads
     - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false
-install:
-  - "pip install -e .[dev]"
-  - "pip install ltd-conveyor"
+      install:
+        - "pip install Sphinx==2.3.*"
+        - "pip install .[dev]"
+    - python: "3.7"
+      install:
+        - "pip install Sphinx==2.2.*"
+        - "pip install .[dev]"
+    - python: "3.7"
+      install:
+        - "pip install Sphinx==2.1.*"
+        - "pip install .[dev]"
+    - python: "3.7"
+      install:
+        - "pip install Sphinx==2.0.*"
+        - "pip install .[dev]"
 script:
   - "python setup.py test"
   - "cd docs && make linkcheck && make html && cd ../"
 after_success:
+  - "pip install ltd-conveyor"
   - 'ltd upload --product "documenteer" --travis --dir docs/_build/html'
 env:
   global:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,9 @@ Change Log
 
 - Updated the MathJax CDN URL to point to cdnjs.
 
+- Added static type checking using `pytest-mypy <https://github.com/dbader/pytest-mypy>`__.
+  :jirab:`DM-22717`
+
 0.5.5 (2019-12-09)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from typing import List
 
 from documenteer.sphinxconfig.utils import form_ltd_edition_name
 import lsst_sphinx_bootstrap_theme
@@ -139,7 +140,7 @@ html_short_title = 'Documenteer'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path: List[str] = []
 
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False

--- a/documenteer/conf/technote.py
+++ b/documenteer/conf/technote.py
@@ -74,11 +74,12 @@ __all__ = (
 
 import datetime
 from pathlib import Path
+from typing import Any, Optional, Dict, List, Tuple, Union
 
 import lsst_dd_rtd_theme
 import yaml
 
-from ..sphinxconfig.utils import (
+from documenteer.sphinxconfig.utils import (
     read_git_branch,
     get_project_content_commit_date)
 
@@ -127,8 +128,13 @@ if 'version' in _metadata:
     version = _metadata['version']
 
 # The edit_url is used for "Edit on GitHub" functionality
+_github_url: Optional[str]
+_edit_url: Optional[str]
 if 'github_url' in _metadata:
     _github_url = _metadata['github_url']
+else:
+    _github_url = None
+if _github_url is not None:
     if not _github_url.endswith('/'):
         _github_url = _github_url + '/'
     _edit_url = '{_github_url}blob/{_git_branch}/index.rst'
@@ -210,7 +216,7 @@ html_theme_path = [lsst_dd_rtd_theme.get_html_theme_path()]
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {}
+html_theme_options: Dict[str, Any] = {}
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -243,7 +249,7 @@ else:
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = []
+html_extra_path: List[str] = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.
@@ -294,6 +300,6 @@ mathjax_path = (
 # ============================================================================
 # #INTER Intersphinx configuration
 # ============================================================================
-intersphinx_mapping = {}
+intersphinx_mapping: Dict[str, Tuple[Union[str, None]]] = {}
 intersphinx_timeout = 10.0  # seconds
 intersphinx_cache_limit = 5  # days

--- a/documenteer/sphinxext/lssttasks/configfieldlists.py
+++ b/documenteer/sphinxext/lssttasks/configfieldlists.py
@@ -8,6 +8,7 @@ __all__ = (
 )
 
 import functools
+from typing import Dict, Callable, Any
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -22,7 +23,9 @@ from .crossrefs import (pending_task_xref, pending_config_xref,
                         format_configfield_id)
 
 
-FIELD_FORMATTERS = {}
+# FIXME import typing of the lsst.pex.config.Field and
+# docutils.statemachine.State parameters.
+FIELD_FORMATTERS: Dict[str, Callable[[str, Any, str, Any, int], Any]] = {}
 """Internal mapping of field type strings to formatter functions.
 
 External users should access this through `get_field_formatter`.

--- a/documenteer/sphinxext/packagetoctree.py
+++ b/documenteer/sphinxext/packagetoctree.py
@@ -7,11 +7,7 @@ __all__ = ('setup', 'ModuleTocTree', 'PackageTocTree')
 import docutils
 from docutils.parsers.rst import Directive, directives
 import sphinx
-try:
-    # Sphinx 1.6+
-    from sphinx.util.logging import getLogger
-except ImportError:
-    getLogger = None
+from sphinx.util.logging import getLogger
 from sphinx.util.nodes import set_source_info
 from pkg_resources import get_distribution, DistributionNotFound
 
@@ -47,12 +43,7 @@ class ModuleTocTree(Directive):
         new_nodes : `list`
             Nodes to add to the doctree.
         """
-        if getLogger is not None:
-            # Sphinx 1.6+
-            logger = getLogger(__name__)
-        else:
-            # Previously Sphinx's app was also the logger
-            logger = self.state.document.settings.env.app
+        logger = getLogger(__name__)
 
         env = self.state.document.settings.env
         new_nodes = []
@@ -140,12 +131,7 @@ class PackageTocTree(Directive):
         new_nodes : `list`
             Nodes to add to the doctree.
         """
-        if getLogger is not None:
-            # Sphinx 1.6+
-            logger = getLogger(__name__)
-        else:
-            # Previously Sphinx's app was also the logger
-            logger = self.state.document.settings.env.app
+        logger = getLogger(__name__)
 
         env = self.state.document.settings.env
         new_nodes = []

--- a/documenteer/sphinxrunner.py
+++ b/documenteer/sphinxrunner.py
@@ -8,11 +8,7 @@ import logging
 import sys
 
 from sphinx.application import Sphinx
-try:
-    from sphinx.cmd.build import handle_exception
-except ImportError:
-    # Sphinx <1.8
-    from sphinx.cmdline import handle_exception
+from sphinx.cmd.build import handle_exception
 from sphinx.util.docutils import docutils_namespace, patch_docutils
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,7 @@ test=pytest
 max-line-length = 79
 
 [tool:pytest]
-addopts = --flake8 --cov=documenteer
+addopts = --flake8 --mypy --cov=documenteer
+
+[mypy]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ extras_require = {
         'pytest-cov==2.6.1',
         'pytest-flake8==1.0.4',
         'pytest-mock==1.4.0',
+        'pytest-mypy==0.4.2',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?
         'sphinx-click==2.3.1',


### PR DESCRIPTION
Added static type checking using [pytest-mypy](https://github.com/dbader/pytest-mypy). The goal in this PR is to add type checking to the CI tests and to modify the code as lightly as possible to make this happen.

I'm using the `ignore_missing_imports = True` flag to avoid adding stubs for third-party packages at this point.