### PR TITLE
DM-23095: Drop the use of pytest-runner (0.5.6 release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 git:
   # Clone the full depth for setuptools_scm (to count commits in very large
@@ -14,10 +13,10 @@ matrix:
     - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false
 install:
-  - "pip install -e .[dev]"
+  - "pip install .[dev]"
   - "pip install ltd-conveyor"
 script:
-  - "python setup.py test"
+  - "pytest"
   - "cd docs && make linkcheck && make html && cd ../"
 after_success:
   - 'ltd upload --product "documenteer" --travis --dir docs/_build/html'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+0.5.6 (2020-01-16)
+------------------
+
+- Dropped the use of `pytest-runner <https://pypi.org/project/pytest-runner/>`_, since it's now deprecated.
+  :jirab:`DM-23095`
+
 0.5.5 (2019-12-09)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ tests_require = extras_require['dev']
 
 setup_requires = [
     'setuptools_scm',
-    'pytest-runner>=2.11.1,<3',
 ]
 
 console_scripts = [


### PR DESCRIPTION
This PR drops the use of pytest-runner from the Documenteer 0.5 release line. pytest-runner as a whole is deprecated, and it's also interfering with the Conda build of Documenteer.