### PR TITLE
DM-22461: Add an autocppapi directive that lists contents in a C++ namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,12 +54,15 @@ Change Log
   ReStructuredText content can now link into embedded Doxygen-generate site using the `sphinxcontrib-doxylink <https://sphinxcontrib-doxylink.readthedocs.io/en/latest/>`_ extension with the new ``lsstcc`` role.
   Authors can use a new command, ``stack-docs listcc`` to find available APIs for linking.
 
+  There is a new directive, ``autocppapi``, part of the ``documenteer.ext.autocppapi`` extension, that helps you list and link to C++ APIs in a namespace.
+  It's intended to be used equivalently to the ``automodapi`` extension.
+
   The built-in Doxygen build considers all Stack packages with a ``doc/doxygen.conf.in`` file.
   Documenteer creates a Doxygen configuration from the contents of each package's ``doxygen.conf.in`` file, along with built-in defaults appropriate for pipelines.lsst.io.
   For example, individual packages can add to the ``EXCLUDE`` tag.
   By default, each package's ``include`` directory is included in the Doxygen build.
 
-  [:jira:`DM-22698`, :jira:`DM-23094`]
+  [:jira:`DM-22698`, :jira:`DM-23094`, :jira:`DM-22461`]
 
 - Added static type checking using `pytest-mypy <https://github.com/dbader/pytest-mypy>`__.
   :jirab:`DM-22717`

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,6 +2,8 @@
 Installing Documenteer
 ######################
 
+.. _pip-install:
+
 Installation with pip
 =====================
 

--- a/docs/sphinx-extensions/autocppapi.rst
+++ b/docs/sphinx-extensions/autocppapi.rst
@@ -1,0 +1,79 @@
+.. default-domain:: rst
+
+#######################################################################
+The autocppapi extension for listing Doxylink C++ APIs through Doxylink
+#######################################################################
+
+Documenteer provides an :dir:`autocppapi` directive that serves a similar role as automodapi_, but instead provides a listing of APIs in a C++ namespace.
+The :dir:`autocppapi` works with Doxylink_ to link to APIs in a Doxygen site.
+
+.. _automodapi: https://sphinx-automodapi.readthedocs.io/en/latest/
+.. _Doxylink: http://sphinxcontrib-doxylink.readthedocs.io/en/stable/
+
+To use this directive, add the ``documenteer.ext.autocppapi`` extension to your :file:`conf.py` file:
+
+.. code-block:: python
+
+   extensions = [
+       ...,
+       'sphinxcontrib.doxylink',
+       'documenteer.ext.autocppapi'
+   ]
+
+.. important::
+
+   The ``autocppapi`` extension needs Doxylink to be installed and also included in the extensions listing.
+   If you installed ``autocppapi`` through the :ref:`"pipelines" extra <pip-install>`, Doxylink will be installed for you.
+   Doxylink is automatically configured in Pipelines documentation builds to point to a Doxygen site that's embedded during the build process (see :doc:`/pipelines/build-overview`).
+   Otherwise, you can manually add Doxylink to your project's depenencies:
+
+   .. prompt:: bash
+
+      pip install sphinxcontrib-doxylink
+
+autocppapi directive
+====================
+
+.. directive:: .. autocppapi:: namespace
+
+   Create a listing of APIs associated with the given namespace.
+   The listing is broken into subsections for each type of API:
+
+   - Classes
+   - Structs
+   - Functions
+   - Variables
+   - Defines
+
+   Each listed item is a link into the Doxygen C++ API reference.
+
+   **Example**
+
+   .. code-block:: rst
+
+      .. autocppapi:: lsst::afw::image
+
+   This example produces a listing of APIs associated with the ``lsst::afw::image`` namespace.
+   In order to use ``autocppapi`` like this, without additional options, you need to set the ``documenteer_autocppapi_doxylink_role`` configuration value in your :file:`conf.py` file.
+
+   **Options**
+
+   ``:doxylink-role:`` role-name
+      Set this option to the name of the Doxylink role instead of using the ``documenteer_autocppapi_doxylink_role`` configuration variable.
+
+Configurations
+==============
+
+``documenteer_autocppapi_doxylink_role``
+    Set this configuration variable to the name of the Doxylink role.
+    As an example, this is how pipelines.lsst.io configures the extension:
+
+    .. code-block:: python
+
+       doxylink = {
+           'lsstcc': ('_doxygen/doxygen.tag', 'cpp-api')
+       }
+
+       documenteer_autocppapi_doxylink_role = 'lsstcc'
+
+    To override this configuration on a per-\ ``autocppapi`` directive basis, you can use the directive's ``:doxylink-role:`` option instead.

--- a/docs/sphinx-extensions/autocppapi.rst
+++ b/docs/sphinx-extensions/autocppapi.rst
@@ -41,7 +41,6 @@ autocppapi directive
 
    - Classes
    - Structs
-   - Functions
    - Variables
    - Defines
 

--- a/docs/sphinx-extensions/index.rst
+++ b/docs/sphinx-extensions/index.rst
@@ -6,6 +6,7 @@ Sphinx extensions provided by Documenteer
    :maxdepth: 2
 
    lssttasks
+   autocppapi
    jira-reference
    docushare-reference
    remote-code-block

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -83,6 +83,7 @@ __all__ = (
     'autodoc_default_flags',
     # DOXYLINK
     'doxylink',
+    'documenteer_autocppapi_doxylink_role',
     # GRAPHVIZ
     'graphviz_output_format',
     'graphviz_dot_args',
@@ -123,7 +124,8 @@ extensions = [
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
     'documenteer.sphinxext',
-    'documenteer.sphinxext.lssttasks'
+    'documenteer.sphinxext.lssttasks',
+    'documenteer.ext.autocppapi',
 ]
 
 # ============================================================================
@@ -340,6 +342,8 @@ autodoc_default_flags = [
 doxylink = {
     'lsstcc': ('_doxygen/doxygen.tag', 'cpp-api')
 }
+
+documenteer_autocppapi_doxylink_role = 'lsstcc'
 
 # ============================================================================
 # #GRAPHVIZ graphviz configuration

--- a/documenteer/ext/autocppapi.py
+++ b/documenteer/ext/autocppapi.py
@@ -125,12 +125,12 @@ class AutoCppApi(SphinxDirective):
 
         node_list: List[nodes.Node] = []
 
+        # Map of doxylink.SymbolMap API types with headers.
+        # There are additional types (such as `function`, `typedef`, and
+        # `enumerations`), but these are generally scoped in classes already.
         api_kinds = [
             ('class', 'Classes'),
             ('struct', 'Structs'),
-            # ('function', 'Functions'),
-            # ('typedef', 'Typedefs'),
-            # ('enumerations', 'Enumerations'),
             ('variable', 'Variables'),
             ('define', 'Defines'),
         ]

--- a/documenteer/ext/autocppapi.py
+++ b/documenteer/ext/autocppapi.py
@@ -2,11 +2,11 @@
 a namespace.
 """
 
-__all__ = ['setup', 'AutoCppApi']
+__all__ = ['setup', 'AutoCppApi', 'filter_symbolmap']
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Sequence, Optional, Any
+from typing import TYPE_CHECKING, Dict, Set, List, Optional, Any
 import xml.etree.ElementTree as ET
 
 from docutils import nodes
@@ -68,9 +68,32 @@ def load_symbolmap(
 
 def filter_symbolmap(
     symbol_map: doxylink.SymbolMap,
-    kinds: Optional[Sequence[str]] = None,
+    kinds: Optional[Set[str]] = None,
     match: Optional[str] = None
 ) -> List[str]:
+    """Filter the entries in a symbol map to only those that match a certain
+    API type or name regular expression.
+
+    Parameters
+    ----------
+    symbol_map : ``doxylink.SymbolMap``
+        The Doxylink SymbolMap.
+    kinds : `set` of `str`, optional
+        The kinds of APIs to filter for. The class-like APIs are:
+
+        - ``class``
+        - ``struct``
+        - ``union``
+        - ``interface``
+    match : `str`
+        A string that can be compiled into a regular expression. This regular
+        expression matches APIs
+
+    Returns
+    -------
+    names : `list` of `str`
+        The names of APIs that match the criteria.
+    """
     names: List[str] = []
     pattern: Optional[Any]
     if match:

--- a/documenteer/ext/autocppapi.py
+++ b/documenteer/ext/autocppapi.py
@@ -4,7 +4,9 @@ a namespace.
 
 __all__ = ['setup', 'AutoCppApi']
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Any
+import xml.etree.ElementTree as ET
 
 from docutils.nodes import Node
 from docutils.parsers.rst import directives
@@ -23,6 +25,42 @@ except ImportError:
 
 if TYPE_CHECKING:
     import sphinx.application
+    import sphinx.config
+
+
+def cache_doxylink_symbolmap(
+        app: 'sphinx.application.Sphinx',
+        config: 'sphinx.config.Config',
+        ) -> None:
+    """Cache the doxylink SymbolMap used by the AutoCppApi directive, into
+    the environment.
+
+    This is connected to the ``config-inited`` event.
+    """
+    doxylink_role: str = config['documenteer_autocppapi_doxylink_role']
+    symbol_map = load_symbolmap(doxylink_role, config)
+    key = 'documenteer_autocppapi_symbolmaps'
+    if key in config:
+        if isinstance(config[key], dict):
+            config[key][doxylink_role] = symbol_map  # type: ignore
+    else:
+        config[key] = {doxylink_role: symbol_map}
+
+
+def load_symbolmap(
+    doxylink_role: str,
+    config: 'sphinx.config.Config'
+) -> doxylink.SymbolMap:
+    """Load the doxylink SymbolMap given Sphinx configuration.
+    """
+    if doxylink_role in config['doxylink']:
+        if isinstance(config['doxylink'], dict):
+            if isinstance(config['doxylink'][doxylink_role], tuple):
+                tag_path = Path(config['doxylink'][doxylink_role][0])
+                doc = ET.parse(str(tag_path))
+                return doxylink.SymbolMap(doc)
+    raise RuntimeError(
+        f'Could not load tag file for Doxylink {doxylink_role} role')
 
 
 class AutoCppApi(SphinxDirective):
@@ -56,6 +94,9 @@ def setup(app: "sphinx.application.Sphinx") -> Dict[str, Any]:
     # Configuration values
     app.add_config_value(
         'documenteer_autocppapi_doxylink_role', '', 'html')
+
+    # Events
+    app.connect('config-inited', cache_doxylink_symbolmap)
 
     # Directives
     app.add_directive('autocppapi', AutoCppApi)

--- a/documenteer/ext/autocppapi.py
+++ b/documenteer/ext/autocppapi.py
@@ -1,0 +1,67 @@
+"""Sphinx extension to generate a list of doxylink-based links to C++ APIs in
+a namespace.
+"""
+
+__all__ = ['setup', 'AutoCppApi']
+
+from typing import TYPE_CHECKING, Dict, List, Any
+
+from docutils.nodes import Node
+from docutils.parsers.rst import directives
+from pkg_resources import get_distribution
+from sphinx.util.docutils import SphinxDirective
+
+try:
+    from sphinxcontrib.doxylink import doxylink
+except ImportError:
+    print(
+        'sphinxcontrib.doxylink is missing. Install documenteer with the '
+        'pipelines extra:\n\n  pip install documenteer[pipelines]'
+    )
+    raise
+
+
+if TYPE_CHECKING:
+    import sphinx.application
+
+
+class AutoCppApi(SphinxDirective):
+    """The ``autocppapi`` directive that lists C++ APIs within a namespace,
+    as detected by doxylink.
+    """
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = False
+    has_content = False
+    option_spec = {
+        'doxylink-role': directives.unchanged,
+    }
+
+    def run(self) -> List[Node]:
+        """Execute the directive.
+        """
+        if 'doxylink-role' in self.options:
+            doxylink_role = self.options['doxylink-role']
+        else:
+            doxylink_role = self.env.config[
+                'documenteer_autocppapi_doxylink_role']
+
+        namespace_prefix = self.arguments[0]
+
+
+def setup(app: "sphinx.application.Sphinx") -> Dict[str, Any]:
+    """Set up the ``documenteer.ext.autocppapi`` Sphinx extensions.
+    """
+    # Configuration values
+    app.add_config_value(
+        'documenteer_autocppapi_doxylink_role', '', 'html')
+
+    # Directives
+    app.add_directive('autocppapi', AutoCppApi)
+
+    return {
+        'version': get_distribution('documenteer').version,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True
+    }

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,9 @@ dev =
     pytest-flake8==1.0.4
     pytest-mock==1.4.0
     pytest-mypy==0.4.2
+    # Test depedendencies for analyzing HTML output
+    lxml==4.4.2
+    cssselect==1.1.0
     # Extensions for documenteer's own docs
     lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0
     numpydoc==0.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+from typing import List
+
+import pytest
+from sphinx.testing.path import path
+
+
+pytest_plugins = ('sphinx.testing.fixtures',)
+
+# Exclude 'roots' dirs for pytest test collector
+collect_ignore: List[str] = ['roots']
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "sphinx(builder, testroot='name'): Run sphinx on a site"
+    )
+
+
+@pytest.fixture(scope='session')
+def rootdir() -> path:
+    """Directory containing Sphinx projects for testing (`str`).
+    """
+    return path(__file__).parent.abspath() / 'roots'

--- a/tests/roots/test-autocppapi/conf.py
+++ b/tests/roots/test-autocppapi/conf.py
@@ -1,0 +1,25 @@
+from zipfile import ZipFile
+from pathlib import Path
+
+
+project = 'autocppapi test site'
+
+extensions = [
+    'sphinxcontrib.doxylink',
+    'documenteer.ext.autocppapi'
+]
+
+exclude_patterns = ['_build', '_includes', 'doxygen.tag', 'doxygen.tag.zip']
+
+# Install the test doxygen.tag file.
+base_dir = Path(__file__).parent
+zip_tag_path = base_dir / 'doxygen.tag.zip'
+with ZipFile(zip_tag_path) as tagzip:
+    tagzip.extract('doxygen.tag', path=base_dir)
+tag_path = base_dir / 'doxygen.tag'
+
+doxylink = {
+    'lsstcc': (str(tag_path), 'cpp-api')
+}
+
+documenteer_autocppapi_doxylink_role = 'lsstcc'

--- a/tests/roots/test-autocppapi/doxygen.tag.zip
+++ b/tests/roots/test-autocppapi/doxygen.tag.zip
@@ -1,0 +1,1 @@
+../../data/doxygen.tag.zip

--- a/tests/roots/test-autocppapi/index.rst
+++ b/tests/roots/test-autocppapi/index.rst
@@ -2,7 +2,7 @@
 autocppapi test site
 ####################
 
-lsst::utils
-===========
+C++ API reference
+=================
 
 .. autocppapi:: lsst::utils

--- a/tests/roots/test-autocppapi/index.rst
+++ b/tests/roots/test-autocppapi/index.rst
@@ -1,0 +1,8 @@
+####################
+autocppapi test site
+####################
+
+lsst::utils
+===========
+
+.. autocppapi:: lsst::utils

--- a/tests/test_ext_autocppapi.py
+++ b/tests/test_ext_autocppapi.py
@@ -1,0 +1,47 @@
+"""Tests for documenteer.ext.autocppapi.
+"""
+
+import lxml.html
+import pytest
+from sphinx.util import logging
+
+
+@pytest.mark.sphinx('html', testroot='autocppapi')
+def test_example_page_rendering(app, status, warning):
+    """Test against the ``test-autocppapi`` test root.
+
+    These tests ensure that automodapi is generating subsections for
+    each API type (Classes, Structs, Variables in this case), and that the
+    items have links into the doxygen docs.
+    """
+    # examples_source_dir = os.path.join(
+    #     app.srcdir, app.config.astropy_examples_dir)
+    app.verbosity = 2
+    logging.setup(app, status, warning)
+    app.builder.build_all()
+
+    index_path = app.outdir / 'index.html'
+    with open(index_path, 'r') as f:
+        html_source = f.read()
+    doc = lxml.html.document_fromstring(html_source)
+
+    section = doc.cssselect('#lsst-utils')[0]
+
+    headers = [
+        'Classes¶',
+        'Structs¶',
+        'Variables¶'
+    ]
+
+    for div in section.cssselect('div'):
+        header = div.cssselect('h3')[0]
+        assert header.text_content() in headers
+
+        ul = div.cssselect('ul')[0]
+
+        if header == 'Variables¶':
+            li0 = ul.cssselect('a')[0]
+            assert li0.attrib['href'] == (
+                'cpp-api/classlsst_1_1utils_1_1python_1_1_wrapper_'
+                'collection.html#abc61644ff7791a730da4ec8f6057365a'
+            )

--- a/tests/test_ext_autocppapi.py
+++ b/tests/test_ext_autocppapi.py
@@ -25,23 +25,13 @@ def test_example_page_rendering(app, status, warning):
         html_source = f.read()
     doc = lxml.html.document_fromstring(html_source)
 
-    section = doc.cssselect('#lsst-utils')[0]
+    section = doc.cssselect('#cppapi-lsst-utils')[0]
 
-    headers = [
-        'Classes¶',
-        'Structs¶',
-        'Variables¶'
-    ]
+    headline = section.cssselect('h3')[0]
+    assert headline.text_content() == 'lsst::utils¶'
 
-    for div in section.cssselect('div'):
-        header = div.cssselect('h3')[0]
-        assert header.text_content() in headers
-
-        ul = div.cssselect('ul')[0]
-
-        if header == 'Variables¶':
-            li0 = ul.cssselect('a')[0]
-            assert li0.attrib['href'] == (
-                'cpp-api/classlsst_1_1utils_1_1python_1_1_wrapper_'
-                'collection.html#abc61644ff7791a730da4ec8f6057365a'
-            )
+    ul = section.cssselect('ul')[0]
+    li0 = ul.cssselect('a')[0]
+    assert li0.attrib['href'] \
+        == './cpp-api/classlsst_1_1utils_1_1_backtrace.html'
+    assert li0.text_content() == 'lsst::utils::Backtrace'


### PR DESCRIPTION
The `autocppapi` directive is the C++ equivalent of the `automodapi` we use for listing Python APIs. It's made to integrate with the doxylink extension. Example:

```rst
.. autocppapi:: lsst::afw::table
```

This lists classes, structs, etc. that include `lsst::afw::table`` in their signature.