### PR TITLE
DM-23661: Unpin click dependency in 0.5 series

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.5.7 (2020-02-26)
+------------------
+
+- The `Click <https://click.palletsprojects.com/en/7.x/>`__ dependency is no longer pinned (previously it was pinned ``<=7``).
+
 0.5.6 (2020-01-16)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     'sphinx-prompt',
     'GitPython',
     'requests',
-    'click>=6.7,<7.0'
+    'click'
 ]
 
 # Project-specific dependencies


### PR DESCRIPTION
The [Click](https://click.palletsprojects.com/en/7.x/) dependency is no longer pinned (previously it was pinned `<=7`).

This improves compatibility with installations that also include cookiecutter, which requires click 7+.

For release as 0.5.7.