### PR TITLE
DM-26768: Remove pins on [pipelines] extra dependencies 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Run mypy
+      - name: Run tox
         run: tox -e py-test-sphinx${{ matrix.sphinx-version }}
 
   typing:
@@ -80,7 +80,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
 
-      - name: Run tests
+      - name: Run mypy
         run: tox -e typing-sphinx${{ matrix.sphinx-version }}
 
   docs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,16 +13,9 @@ Change Log
 
   - ``pip install documenteer[technote]`` installs the core dependencies required by Documenteer, as well as the pinned Sphinx theme and extensions used by all technote projects.
 
-  - ``pip install documenteer[pipelines]`` installs the core dependencies required by Documenteer, as well as the pinned Sphinx theme and extensions used by pipelines.lsst.io.
-
-  Specific dependency upgrades:
-
-  - The ``click`` version now floats.
-  - ``numpydoc`` is pinned at 0.8.0.
-  - ``sphinx-automodapi`` is pinned at 0.12.
-  - ``breathe`` is dropped.
-  - ``sphinx-prompt`` is moved from a core dependency to an extra.
-  - ``sphinxcontrib.doxylink`` is a new extension for Pipelines projects to link the embedded Doxygen-generated C++ reference.
+  - ``pip install documenteer[pipelines]`` installs the core dependencies required by Documenteer, as well as the Sphinx theme and extensions used by pipelines.lsst.io.
+    These extensions no longer have pinned versions.
+    However, because of an automodapi 0.13 compatibility issue with Sphinx, the Sphinx version for ``[pipelines]`` is pinned ``<3.0``.
 
   Updates to development or test dependencies:
 
@@ -63,6 +56,9 @@ Change Log
   By default, each package's ``include`` directory is included in the Doxygen build.
 
   [`DM-22698 <https://jira.lsstcorp.org/browse/DM-22698>`_, `DM-23094 <https://jira.lsstcorp.org/browse/DM-23094>`_, `DM-22461 <https://jira.lsstcorp.org/browse/DM-22461>`_]
+
+- Improved Sphinx runner (``documenteer.sphinxrunner``).
+  [`DM-26768 <https://jira.lsstcorp.org/browse/DM-26768>`__]
 
 - Added static type checking using `mypy <https://mypy.readthedocs.io/en/stable/>`__.
   [`DM-22717 <https://jira.lsstcorp.org/browse/DM-22717>`_, `DM-26288 <https://jira.lsstcorp.org/browse/DM-26288>`_]

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -22,8 +22,6 @@ For additional documentation, see:
 #     automodapi and autodoc configuration
 # #GRAPHVIZ
 #     graphviz configuration
-# #MATPLOTLIB
-#     matplotlib extension configuration
 # #TODO
 #     todo extension configuration
 # #EUPS
@@ -100,7 +98,6 @@ __all__ = (
 
 import datetime
 import os
-import warnings
 
 import lsst_sphinx_bootstrap_theme
 
@@ -355,22 +352,6 @@ graphviz_dot_args = [
     "-Gfontsize=10",
     "-Gfontname=Helvetica Neue, Helvetica, Arial, sans-serif",
 ]
-
-# ============================================================================
-# #MATPLOTLIB matplotlib extension configuration
-# ============================================================================
-try:
-    import matplotlib.sphinxext.plot_directive
-
-    extensions += [matplotlib.sphinxext.plot_directive.__name__]
-except (ImportError, AttributeError):
-    # AttributeError is checked here in case matplotlib is installed but
-    # Sphinx isn't.  Note that this module is imported by the config file
-    # generator, even if we're not building the docs.
-    warnings.warn(
-        "matplotlib's plot_directive could not be imported. "
-        "Inline plots will not be included in the output."
-    )
 
 # ============================================================================
 # #TODO todo extension configuration

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -122,6 +122,7 @@ extensions = [
     "documenteer.sphinxext",
     "documenteer.sphinxext.lssttasks",
     "documenteer.ext.autocppapi",
+    "sphinx_click",
 ]
 
 # ============================================================================

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ technote =
     sphinxcontrib-bibtex==1.0.0
     sphinx-prompt
 pipelines =
+    Sphinx<3.0.0 # due to automodapi<=0.12 bugs
     # Theme and extensions for pipelines.lsst.io
     lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0
     numpydoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,12 +59,12 @@ technote =
 pipelines =
     # Theme and extensions for pipelines.lsst.io
     lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0
-    numpydoc==0.8.0
-    sphinx-automodapi==0.12
-    sphinx-jinja==1.1.0
-    sphinxcontrib-autoprogram>=0.1.5,<0.2.0
+    numpydoc
+    sphinx-automodapi
+    sphinx-jinja
+    sphinxcontrib-autoprogram
     sphinx-prompt
-    sphinxcontrib-doxylink>=1.6.0,<1.7.0
+    sphinxcontrib-doxylink
 dev =
     # Documenteer's testing and deployment deps
     coverage[toml]

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ pipelines =
     sphinxcontrib-autoprogram
     sphinx-prompt
     sphinxcontrib-doxylink
+    sphinx-click
 dev =
     # Documenteer's testing and deployment deps
     coverage[toml]


### PR DESCRIPTION
- Remove pins on `[pipelines]` extra to better keep up with third-party improvements.
- For `[pipelines]`, pin the Sphinx version as <3, >2 because of an automodapi incompatibility with Sphinx 3. This is already resolved on their master branch, and thus we're awaiting a 0.13 release of automodapi.
- Add the sphinx_click extension to the `[pipelines]` extra.