### PR TITLE
DM-27020: Remove breathe from deprecated documenteer.sphinxconf Sphinx configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+0.6.1 (2020-10-06)
+------------------
+
+Fixes:
+
+- Removed the ``breathe`` extension from the deprecated ``documenteer.sphinxconf`` Sphinx configuration for Pipelines documentation.
+  This is because documenteer no longer includes ``breathe`` in its dependencies.
+  Though this is backwards incompatible, ``breathe`` was never used in production documentation.
+
 0.6.0 (2020-10-01)
 ------------------
 

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -35,7 +35,6 @@ def _insert_extensions(c):
         "numpydoc",
         "sphinx_automodapi.automodapi",
         "sphinx_automodapi.smart_resolver",
-        "breathe",
         "documenteer.sphinxext",
         "documenteer.sphinxext.lssttasks",
     ]


### PR DESCRIPTION
Removed the ``breathe`` extension from the deprecated ``documenteer.sphinxconf`` Sphinx configuration for Pipelines documentation. This is because documenteer no longer includes ``breathe`` in its dependencies. Though this is backwards incompatible, ``breathe`` was never used in production documentation.