### PR TITLE
DM-28543: Compatibility with sphinxcontrib-bibtex 2.0+

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.2
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
 
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.2
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 0 # full depth for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v2.1.2
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
@@ -93,7 +93,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
@@ -125,7 +125,7 @@ jobs:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
         python-version:
           - 3.7
           - 3.8
+          - 3.9
         sphinx-version:
           - "23"
           - "latest"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+0.6.3 (2020-02-01)
+------------------
+
+Fixes:
+
+- Documenteer works with the latest version of `sphinxcontrib-bibtex`_.
+  Both the new (``documenteer.conf.technote``) and old (``documenteer.sphinxconfig.technoteconf``) versions of the technote configuration use the new ``bibtex_bibfiles`` configuration variable.
+  Version 2.0.0 or later of `sphinxcontrib-bibtex`_ is now required because of that package's API.
+
 0.6.2 (2020-10-08)
 ------------------
 
@@ -448,3 +457,4 @@ Includes prototype support for LSST Science Pipelines documentation, as part of 
 .. _sconsUtils: https://github.com/lsst/sconsUtils
 .. _lsstDoxygen: https://github.com/lsst/lsstDoxygen
 .. _base: https://github.com/lsst/base
+.. _sphinxcontrib-bibtex: https://sphinxcontrib-bibtex.readthedocs.io/

--- a/docs/pipelines/cpp-api-linking.rst
+++ b/docs/pipelines/cpp-api-linking.rst
@@ -66,7 +66,7 @@ The Sphinx configuration for the pipelines.lsst.io project includes a special :r
 Listing linkable C++ APIs (stack-docs listcc)
 =============================================
 
-Documenteer includes the `stack-docs listcc <stack-docs-cli.html#stack-docs-listcc>`_ command that helps you find C++ APIs that are linkable with the :role:`lsstcc` role.
+Documenteer includes the :doc:`stack-docs listcc <stack-docs-cli>` command that helps you find C++ APIs that are linkable with the :role:`lsstcc` role.
 The APIs are automatically escaped so that you can copy-and-paste them into the :role:`lsstcc` role in a reStructuredText document.
 
 From the pipelines_lsst_io_ project repository, run the command to see the signatures of all available APIs:

--- a/docs/sphinx-extensions/autocppapi.rst
+++ b/docs/sphinx-extensions/autocppapi.rst
@@ -8,7 +8,7 @@ Documenteer provides an :dir:`autocppapi` directive that serves a similar role a
 The :dir:`autocppapi` works with Doxylink_ to link to APIs in a Doxygen site.
 
 .. _automodapi: https://sphinx-automodapi.readthedocs.io/en/latest/
-.. _Doxylink: http://sphinxcontrib-doxylink.readthedocs.io/en/stable/
+.. _Doxylink: https://sphinxcontrib-doxylink.readthedocs.io/en/stable/
 
 To use this directive, add the ``documenteer.ext.autocppapi`` extension to your :file:`conf.py` file:
 

--- a/documenteer/conf/technote.py
+++ b/documenteer/conf/technote.py
@@ -70,6 +70,9 @@ __all__ = (
     "intersphinx_mapping",
     "intersphinx_timeout",
     "intersphinx_cache_limit",
+    # BIBTEX
+    "bibtex_bibfiles",
+    "bibtex_default_style",
 )
 
 import datetime
@@ -300,3 +303,14 @@ mathjax_path = (
 intersphinx_mapping: Dict[str, Tuple[Union[str, None]]] = {}
 intersphinx_timeout = 10.0  # seconds
 intersphinx_cache_limit = 5  # days
+
+# ============================================================================
+# #BIBTEX sphinxcontrib-bibtex configuration
+# ============================================================================
+bibtex_bibfiles = []
+if Path("local.bib").exists():
+    bibtex_bibfiles.append("local.bib")
+for path in Path("lsstbib").glob("*.bib"):
+    bibtex_bibfiles.append(str(path))
+
+bibtex_default_style = "lsst_aa"

--- a/documenteer/sphinxconfig/technoteconf.py
+++ b/documenteer/sphinxconfig/technoteconf.py
@@ -4,6 +4,7 @@
 __all__ = ("configure_technote",)
 
 import datetime
+import glob
 import os
 
 import lsst_dd_rtd_theme
@@ -175,6 +176,17 @@ def _build_confs(metadata):
     c["intersphinx_mapping"] = {}
     # Add Python 3 intersphinx inventory in projects via
     # c['intersphinx_mapping']['python'] = ('https://docs.python.org/3', None)
+
+    # -- sphinxcontrib-bibtex ------------------------------------------------
+    # -- See https://sphinxcontrib-bibtex.readthedocs.io/
+
+    c["bibtex_bibfiles"] = []
+    if os.path.exists("local.bib"):
+        c["bibtex_bibfiles"].append("local.bib")
+    for path in glob.glob("lsstbib/*.bib"):
+        c["bibtex_bibfiles"].append(path)
+
+    c["bibtex_default_style"] = "lsst_aa"
 
     # -- Options for HTML output ----------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     GitPython
     requests
     click
-    sphinxcontrib-bibtex  # for pybtex plugin
+    sphinxcontrib-bibtex>=2.0.0  # for pybtex plugin; bibtex_bibfiles config is required.
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- Documenteer works with the latest version of `sphinxcontrib-bibtex`_. Both the new (``documenteer.conf.technote``) and old (``documenteer.sphinxconfig.technoteconf``) versions of the technote configuration use the new ``bibtex_bibfiles`` configuration variable. Version 2.0.0 or later of `sphinxcontrib-bibtex`_ is now required because of that package's API.
