### PR TITLE
DM-28543: Fix rst error in long_description and add packaging check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           pip install tox
 
       - name: Run linters
-        run: tox -e lint,docs-lint
+        run: tox -e lint,docs-lint,packaging
 
   test:
     runs-on: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.6.4 (2020-02-02)
+------------------
+
+Fixes:
+
+- Fixed a syntax issue with the package's long description, and added a linting rule to prevent this issue in the future.
+
 0.6.3 (2020-02-01)
 ------------------
 
@@ -215,7 +222,7 @@ Fixes:
 0.4.3 (2018-11-30)
 ------------------
 
-- Pin `sphinxcontrib-bibtex <https://sphinxcontrib-bibtex.readthedocs.io>`__ to version 0.4.0 since later versions are incompatible with Sphinx <1.8.0.
+- Pin `sphinxcontrib-bibtex`_ to version 0.4.0 since later versions are incompatible with Sphinx <1.8.0.
   [`DM-16651 <https://jira.lsstcorp.org/browse/DM-16651>`__]
 
 0.4.2 (2018-11-01)
@@ -442,7 +449,7 @@ Includes prototype support for LSST Science Pipelines documentation, as part of 
 0.1.2 (2016-05-14)
 ------------------
 
-- Include `sphinxcontrib.bibtex <https://github.com/mcmtroffaes/sphinxcontrib-bibtex>`_ to Sphinx extensions available in technote projects. DM-6033.
+- Include `sphinxcontrib-bibtex`_ to Sphinx extensions available in technote projects. DM-6033.
 
 0.1.0 (2015-11-23)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -84,5 +84,5 @@ Sphinx extensions
 - Roles for linking to LSST documents and Jira tickets
 - The ``remote-code-block`` directive
 - The ``module-toctree`` and ``package-toctree`` directives for the LSST Science Pipelines documentation
-- `Extensions for documenting LSST Science Pipelines tasks <https://documenteer.lsst.io/sphinxext/lssttasks.html>`_
-- Support for LSST BibTeX files with `sphinxcontrib-bibtex <http://sphinxcontrib-bibtex.readthedocs.io>`_
+- `Extensions for documenting LSST Science Pipelines tasks <https://documenteer.lsst.io/sphinxext/lssttasks.html>`__
+- Support for LSST BibTeX files with sphinxcontrib-bibtex.

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ pipelines =
     sphinxcontrib-doxylink
     sphinx-click
 dev =
+    twine
     # Documenteer's testing and deployment deps
     coverage[toml]
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -85,8 +85,11 @@ commands = make -C docs linkcheck
 [testenv:packaging]
 description = Check packaging for PyPI with twine
 skip_install = true
+allowlist_externals =
+    rm
 deps =
     twine
 commands =
+    rm -rf dist
     python setup.py sdist bdist_wheel
     twine check dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     typing-sphinxlatest
     coverage-report
     lint
+    packaging
 isolated_build = True
 skip_missing_interpreters = True
 
@@ -80,3 +81,12 @@ description = Build Sphinx documentation
 allowlist_externals =
     make
 commands = make -C docs linkcheck
+
+[testenv:packaging]
+description = Check packaging for PyPI with twine
+skip_install = true
+deps =
+    twine
+commands =
+    python setup.py sdist bdist_wheel
+    twine check dist/*


### PR DESCRIPTION
- Fix a reStructuredText error in the long description
- Add a "packaging" environment to tox to explicitly build the package and run `twine check`. This is a more robust pre-flight of packaging to prevent errors in the PyPI workflow in the future.