### PR TITLE
DM-28802: Update numpy and astropy intersphinx links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.6.5 (2020-02-12)
+------------------
+
+Fixes:
+
+- Updated intersphinx links for Numpy and Astropy in the Pipelines configuration (``documenteer.conf.pipelines`` and ``documenteer.conf.pipelinespkg``).
+
 0.6.4 (2020-02-02)
 ------------------
 

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -188,12 +188,12 @@ exclude_patterns = [
 # ============================================================================
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
     "matplotlib": ("https://matplotlib.org/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "astropy": ("http://docs.astropy.org/en/v3.0.x/", None),
+    "astropy": ("https://docs.astropy.org/en/stable/", None),
     "astro_metadata_translator": (
         "https://astro-metadata-translator.lsst.io",
         None,


### PR DESCRIPTION
Will be released as documenteer 0.6.5.