### PR TITLE
DM-28867: Conditionally configure doxylink in pipelines configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.6.6 (2020-02-17)
+------------------
+
+Fixes:
+
+- Updated the ``documenteer.conf.pipelines`` (and ``documenteer.conf.pipelinespkg``) configuration modules so that they no longer configure ``doxylink`` if the Doxygen tag file is not present.
+  This change is useful for single-package documentation builds of pure-Python packages.
+
 0.6.5 (2020-02-12)
 ------------------
 

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -98,6 +98,7 @@ __all__ = (
 
 import datetime
 import os
+from pathlib import Path
 
 import lsst_sphinx_bootstrap_theme
 
@@ -336,7 +337,11 @@ autodoc_default_flags = ["show-inheritance", "special-members"]
 # ============================================================================
 # #DOXYLINK Doxylink configuration
 # ============================================================================
-doxylink = {"lsstcc": ("_doxygen/doxygen.tag", "cpp-api")}
+tag_path = Path(".").joinpath("_doxygen", "doxygen.tag")
+if tag_path.exists():
+    doxylink = {"lsstcc": (str(tag_path), "cpp-api")}
+else:
+    doxylink = {}
 
 documenteer_autocppapi_doxylink_role = "lsstcc"
 


### PR DESCRIPTION
If the tag file is available, configure doxylink to use it. Otherwise, leave the "doxylink" dictionary empty.

This should prevent many problems with pure-python single-package documentation preview builds.