### PR TITLE
DM-29886: Updates to Pipelines configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+Fixes:
+
+- The ``html_extras_path`` is no longer accidentally reset to ``[""]`` in ``documenteer.conf.pipelines``.
+
 0.6.6 (2020-02-17)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Fixes:
 
 - The ``html_extras_path`` is no longer accidentally reset to ``[""]`` in ``documenteer.conf.pipelines``.
 
+- sphinx-automodapi introduces an autodoc enhancement that replace's autodoc's attr getter for ``type`` with a custom function.
+  However, we're finding that this enhancement is incompatible with Pybind11 static properties that are part of the LSST Science Pipelines API.
+  This release includes a new extension, ``documenteer.ext.autodocreset``, that resets the attr getter for ``type`` to the one built into autodoc.
+  This extension is used by default in ``documenteer.config.pipelines`` and ``documenteer.config.pipelinespkg``.
+
 0.6.6 (2020-02-17)
 ------------------
 

--- a/docs/sphinx-extensions/autodocreset.rst
+++ b/docs/sphinx-extensions/autodocreset.rst
@@ -1,0 +1,22 @@
+.. default-domain:: rst
+
+##########################################################################
+The autodocreset extension for resetting automodapi's autodoc enhancements
+##########################################################################
+
+The `sphinx-automodapi`_ extension includes an ``autodoc_enhancements`` module that replaces autodoc's built-in "attr getter" for ``type``.
+While this enhancement is useful for Python meta programming, it can also be incompatible with Pybind11 static properties, which are present in the LSST Science Pipelines.
+This Sphinx extension resets automodapi's autodoc enhancements and is included by default in the :doc:`Pipelines Sphinx configuration </pipelines/configuration>`.
+
+.. _sphinx-automodapi: https://sphinx-automodapi.readthedocs.io/en/latest/
+
+To use this directive, add ``documenteer.ext.autocppapi`` after both autodoc and automodapi:
+
+.. code-block:: python
+
+   extensions = [
+       "sphinx.ext.autodoc",
+       "sphinx_automodapi.automodapi",
+       "sphinx_automodapi.smart_resolver",
+       "documenteer.ext.autodocreset",
+   ]

--- a/docs/sphinx-extensions/index.rst
+++ b/docs/sphinx-extensions/index.rst
@@ -12,3 +12,4 @@ Sphinx extensions provided by Documenteer
    remote-code-block
    package-toctree
    lsst-pybtex-style
+   autodocreset

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -123,6 +123,7 @@ extensions = [
     "documenteer.sphinxext",
     "documenteer.sphinxext.lssttasks",
     "documenteer.ext.autocppapi",
+    "documenteer.ext.autodocreset",
     "sphinx_click",
 ]
 

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -299,9 +299,6 @@ html_file_suffix = ".html"
 # Language to be used for generating the HTML full-text search index.
 html_search_language = "en"
 
-html_extra_path = [""]
-
-
 # ============================================================================
 # #AUTOMODAPI automodapi and autodoc configuration
 # ============================================================================

--- a/documenteer/ext/autodocreset.py
+++ b/documenteer/ext/autodocreset.py
@@ -1,0 +1,26 @@
+"""Sphinx extension to reset autodoc enhancements made by sphinx-automodapi
+that may be incompatible with LSST Science Pipelines API documentation.
+
+Specifically, the automodapi autodoc enhancement that replaces the attr
+getter for ``type`` is incompatible with pybind11 static properties. This
+extension should be used *after* `sphinx_automodapi.automodapi` to
+reset the autodoc attr getter for ``type`` to the one built into autodoc.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from pkg_resources import get_distribution
+
+if TYPE_CHECKING:
+    import sphinx.application
+
+
+def setup(app: "sphinx.application.Sphinx") -> Dict[str, Any]:
+    """Set up the ``documenteer.ext.autodocreset`` extension."""
+    app.add_autodoc_attrgetter(type, getattr)
+
+    return {
+        "version": get_distribution("documenteer").version,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
- No longer reset `html_extra_path`
- Add a new autodocreset extension that is needed for automodapi compatibility
