### PR TITLE
DM-30085: Trim unnecessary files from Stack doc outputs

### DIFF
--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -183,6 +183,14 @@ exclude_patterns = [
     # shouldn't be in the directory at all, but we certainly need to
     # ignore it while its here.
     "home",
+    # The configuration files
+    "conf.py",
+    "manifest.yaml",
+    "doxygen.conf",
+    "doxygen.conf.in",
+    # Doxygen build products from scons (in stack package builds)
+    "html",
+    "xml",
 ]
 
 # ============================================================================

--- a/documenteer/sphinxrunner.py
+++ b/documenteer/sphinxrunner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 from sphinx.cmd.build import build_main
 
@@ -42,10 +42,16 @@ def run_sphinx(
     """
     src_dir = str(os.path.abspath(root_dir))
 
-    argv: List[str] = [f"-j {job_count}", "-b", "html"]
+    argv = [
+        f"-j {job_count}",
+        "-b",
+        "html",
+        "-d",
+        os.path.join("_build", ".doctrees"),
+    ]
     if warnings_as_errors:
         argv.append("-W")
-    argv.extend([src_dir, "_build/html"])
+    argv.extend([src_dir, os.path.join("_build", "html")])
 
     start_dir = os.path.abspath(".")
     try:


### PR DESCRIPTION
- In the stack-docs build and package-docs build CLIs, set the `-d` command line argument so that `.doctrees` isn't included in the HTML output.
- Use the `exclude_patterns` configuration variable to exclude configuration files such as `conf.py` from the built HTML site. Also, omit the Doxygen output created during scons runs in package documentation builds.