### PR TITLE
DM-32505: Update lsst-dd-rtd-theme to 0.2.4 (for 0.5.9 release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ git:
   depth: false
 matrix:
   include:
-    - python: "3.6"
-      env: PYPI_DEPLOY=false LTD_SKIP_UPLOAD=true
     # Use the Python 3.7 build for PyPI deployments and doc uploads
     - python: "3.7"
       env: PYPI_DEPLOY=true LTD_SKIP_UPLOAD=false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.5.9 (2021-11-08)
+------------------
+
+- Update technote theme to lsst-dd-rtd-theme 0.2.4 to resolve a list formatting issue.
+
 0.5.8 (2020-04-13)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ long_description = read('README.rst')
 # Core dependencies
 install_requires = [
     'Sphinx>=1.7.0,<1.8.0',
+    'docutils<0.18',
     'PyYAML',
     'sphinx-prompt',
     'GitPython',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires = [
 extras_require = {
     # For technical note Sphinx projects
     'technote': [
-        'lsst-dd-rtd-theme==0.2.2',
+        'lsst-dd-rtd-theme==0.2.4',
         # 0.4.1 is incompatible with Sphinx <1.8.0. Unpin once we upgrade
         # Sphinx.
         'sphinxcontrib-bibtex==0.4.0'

--- a/setup.py
+++ b/setup.py
@@ -61,15 +61,15 @@ extras_require = {
 
     # For documenteer development environments
     'dev': [
-        'wheel>=0.29.0',
-        'twine>=1.8.1',
-        'pytest==4.2.0',
-        'pytest-cov==2.6.1',
-        'pytest-flake8==1.0.4',
-        'pytest-mock==1.4.0',
+        'wheel',
+        'twine',
+        'pytest',
+        'pytest-cov',
+        'pytest-flake8',
+        'pytest-mock',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?
-        'sphinx-click>=1.2.0,<1.3.0',
+        'sphinx-click',
     ],
 }
 # Add project dependencies to the dev dependencies


### PR DESCRIPTION
This should resolve unordered list formatting issues with current technotes pinning to documenteer < 0.6