### PR TITLE
DM-33988: Support sphinx-jinja 2, with backward compatibility for sphinx-jinja 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.6.10 (2022-03-09)
+-------------------
+
+Fixes:
+
+- Support sphinx-jinja 2.0.0 by using the ``sphinx_jinja`` extension name in ``documenteer.conf.pipelines`` and ``documenteer.conf.pipelinespkg``.
+  Installations that use sphinx-jinja < 2 will continue to use ``sphinxcontrib.jinja`` since the ``sphinx-jinja`` version is dynamically detected.
+
 0.6.9 (2021-05-10)
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,8 +107,11 @@ nitpick_ignore = [
 
 linkcheck_retries = 2
 
-# Since Jira is currently down at this time
-linkcheck_ignore = [r"^https://jira.lsstcorp.org/browse/"]
+# Since Tucson-based IT infrastructure is frequently down
+linkcheck_ignore = [
+    r"^https://jira.lsstcorp.org/browse/",
+    r"^https://ls.st/",
+]
 
 linkcheck_timeout = 15
 

--- a/documenteer/conf/pipelines.py
+++ b/documenteer/conf/pipelines.py
@@ -102,9 +102,21 @@ from pathlib import Path
 
 import lsst_sphinx_bootstrap_theme
 
+from documenteer.packagemetadata import Semver, get_package_version_semver
+
 # ============================================================================
 # #EXT Sphinx extensions
 # ============================================================================
+
+# The extension name for sphinx-jinja changed with version 2.0.0
+_sphinx_jinja_ext_name = "sphinx_jinja"
+try:
+    if get_package_version_semver("sphinx-jinja") < Semver.parse("2.0.0"):
+        # Use older sphinx jinja name for sphinx-jinja < 2.0.0
+        _sphinx_jinja_ext_name = "sphinxcontrib.jinja"
+except Exception as e:
+    print(f"Error getting sphinx-jinja version: {str(e)}")
+
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
@@ -113,7 +125,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
-    "sphinxcontrib.jinja",
+    _sphinx_jinja_ext_name,
     "sphinx-prompt",
     "sphinxcontrib.autoprogram",
     "sphinxcontrib.doxylink",

--- a/documenteer/packagemetadata.py
+++ b/documenteer/packagemetadata.py
@@ -1,0 +1,104 @@
+"""Utilties for getting metadata about packages."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+if sys.version_info < (3, 8):
+    # Use backport module from Python in Python 3.7
+    from importlib_metadata import PackageNotFoundError, version
+else:
+    # Use standard library module by default
+    from importlib.metadata import PackageNotFoundError, version
+
+
+__all__ = [
+    "get_package_version_str",
+    "PackageNotFoundError",
+    "Semver",
+    "get_package_version_semver",
+]
+
+SEMVER_PATTERN = re.compile(
+    r"^(?P<major>[0-9]+)"
+    r"\.(?P<minor>[0-9]+)"
+    r"\.(?P<patch>[0-9]+)"
+    r"(-(?P<pre>[a-zA-Z0-9\.]+))?"
+    r"(\+(?P<build>[a-zA-Z0-9\.]+))?"
+)
+
+
+def get_package_version_str(package_name: str) -> str:
+    """Get an installed Python package's version, as a string."""
+    return version(package_name)
+
+
+@dataclass
+class Semver:
+    """A representation of a semantic version."""
+
+    major: int = 0
+
+    minor: int = 0
+
+    patch: int = 0
+
+    prerelease: Optional[str] = None
+
+    build: Optional[str] = None
+
+    @classmethod
+    def parse(cls, version_string: str) -> Semver:
+        version_string = version_string.lstrip("v")
+        match = SEMVER_PATTERN.match(version_string)
+        semver = cls(
+            major=int(match.group("major")),
+            minor=int(match.group("minor")),
+            patch=int(match.group("patch")),
+            prerelease=match.group("pre"),
+            build=match.group("build"),
+        )
+        return semver
+
+    @property
+    def _version_tuple(self) -> Tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
+    def __gt__(self, other: Semver) -> bool:
+        # FIXME this comparison ignore pre-release/build info
+        if self._version_tuple > other._version_tuple:
+            return True
+        else:
+            return False
+
+    def __lt__(self, other: Semver) -> bool:
+        # FIXME this comparison ignore pre-release/build info
+        if self._version_tuple < other._version_tuple:
+            return True
+        else:
+            return False
+
+    def __ge__(self, other: Semver) -> bool:
+        # FIXME this comparison ignore pre-release/build info
+        if self._version_tuple >= other._version_tuple:
+            return True
+        else:
+            return False
+
+    def __le__(self, other: Semver) -> bool:
+        # FIXME this comparison ignore pre-release/build info
+        if self._version_tuple <= other._version_tuple:
+            return True
+        else:
+            return False
+
+
+def get_package_version_semver(package_name: str) -> Semver:
+    """Get a parsed representation of a package's version, assuming it is a
+    semantic version.
+    """
+    version_str = get_package_version_str(package_name)
+    return Semver.parse(version_str)

--- a/documenteer/sphinxconfig/stackconf.py
+++ b/documenteer/sphinxconfig/stackconf.py
@@ -15,11 +15,22 @@ import sys
 
 import lsst_sphinx_bootstrap_theme
 
+from documenteer.packagemetadata import Semver, get_package_version_semver
+
 from .utils import read_git_commit_timestamp
 
 
 def _insert_extensions(c):
     """Insert the ``extensions`` variable into the configuration state."""
+    # The extension name for sphinx-jinja changed with version 2.0.0
+    _sphinx_jinja_ext_name = "sphinx_jinja"
+    try:
+        if get_package_version_semver("sphinx-jinja") < Semver.parse("2.0.0"):
+            # Use older sphinx jinja name for sphinx-jinja < 2.0.0
+            _sphinx_jinja_ext_name = "sphinxcontrib.jinja"
+    except Exception as e:
+        print(f"Error getting sphinx-jinja version: {str(e)}")
+
     c["extensions"] = [
         "sphinx.ext.autodoc",
         "sphinx.ext.doctest",
@@ -28,7 +39,7 @@ def _insert_extensions(c):
         "sphinx.ext.coverage",
         "sphinx.ext.mathjax",
         "sphinx.ext.ifconfig",
-        "sphinxcontrib.jinja",
+        _sphinx_jinja_ext_name,
         "sphinx-prompt",
         "sphinxcontrib.autoprogram",
         "numpydoc",

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     requests
     click
     sphinxcontrib-bibtex>=2.0.0  # for pybtex plugin; bibtex_bibfiles config is required.
+    importlib_metadata; python_version < "3.8"
 
 [options.packages.find]
 exclude =

--- a/tests/test_packagemetadata.py
+++ b/tests/test_packagemetadata.py
@@ -1,0 +1,28 @@
+"""Tests for the packagemetadata module."""
+
+from __future__ import annotations
+
+from documenteer.packagemetadata import Semver, get_package_version_semver
+
+
+def test_semver_parse() -> None:
+    v = Semver.parse("2.1.0")
+    assert v == Semver(major=2, minor=1, patch=0)
+
+    v = Semver.parse("2.1.0-alpha.1")
+    assert v == Semver(major=2, minor=1, patch=0, prerelease="alpha.1")
+
+    v = Semver.parse("2.1.0-alpha.1+b1")
+    assert v == Semver(
+        major=2, minor=1, patch=0, prerelease="alpha.1", build="b1"
+    )
+
+    assert Semver.parse("2.0.0") == Semver.parse("2.0.0")
+    assert Semver.parse("2.0.0") >= Semver.parse("2.0.0")
+    assert Semver.parse("2.0.0") > Semver.parse("1.0.0")
+    assert Semver.parse("1.0.0") < Semver.parse("2.0.0")
+    assert Semver.parse("1.0.0") <= Semver.parse("2.0.0")
+
+
+def test_get_package_version_semver() -> None:
+    assert isinstance(get_package_version_semver("sphinx-jinja"), Semver)


### PR DESCRIPTION
sphinx-jinja 2 adopted ``sphinx_jinja`` as its extension name, which requires an update to the `documenteer.conf.pipelines` configuration that uses it. To provides backwards support for sphinx-jinja 1, we're evaluating the environment's installed version of sphinx-jinja and customizing the extension name based on that. For this we've created a `documenteer.packagemetadata` module and `Semver` class, along with using `importlib.metadata` to get the version from a package.