### PR TITLE
DM-34773: Add linking roles for SITCOMTN, etc, documents

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Change Log
 ==========
 
-Unreleased
-----------
+0.6.11 (2022-05-12)
+-------------------
 
 Fixes:
 
@@ -10,8 +10,19 @@ Fixes:
 
 Changes:
 
+- Add new roles for linking to technical notes:
+
+  - sitcomtn
+  - rtn
+  - pstn
+
+- Link to technical notes, which are hosted on lsst.io, now linking directly to lsst.io rather than going through ls.st. This includes the sqr, dmtn, etc. roles and all the new roles mentioned above.
 - Use ``importlib.metadata`` for getting the package version, rather than ``pkg_resources``.
 - Move to a ``src/`` based package layout for consistency.
+
+Issues:
+
+- Temporarily disable testing the Doxygen-related Sphinx extensions.
 
 0.6.10 (2022-03-09)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
     "sphinx_click.ext",
     "sphinxcontrib.autoprogram",
     "sphinx-prompt",
-    "numpydoc",
+    "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
@@ -160,7 +160,26 @@ html_static_path: List[str] = []
 html_show_sourcelink = False
 
 # -- Options for the API reference ----------------------------------------
-numpydoc_show_class_members = False
+
+# sphinx_autodoc_typehints
+always_document_param_types = True
+typehints_defaults = "comma"
+
+# napoleon
+napoleon_google_docstring = False  # non-default
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
 
 # -- ReStructuredText epilog for common links/substitutions ---------------
 rst_epilog = """

--- a/docs/pipelines/configuration.rst
+++ b/docs/pipelines/configuration.rst
@@ -74,13 +74,13 @@ Configuration source reference
 documenteer.conf.pipelines source
 ---------------------------------
 
-.. literalinclude:: ../../documenteer/conf/pipelines.py
+.. literalinclude:: ../../src/documenteer/conf/pipelines.py
 
 .. _pipelinespkg-conf-source:
 
 documenteer.conf.pipelinespkg source
 ------------------------------------
 
-.. literalinclude:: ../../documenteer/conf/pipelinespkg.py
+.. literalinclude:: ../../src/documenteer/conf/pipelinespkg.py
 
 .. _pipelines.lsst.io: https://pipelines.lsst.io

--- a/docs/sphinx-extensions/docushare-reference.rst
+++ b/docs/sphinx-extensions/docushare-reference.rst
@@ -21,121 +21,61 @@ Summary
 
    * - Role
      - Purpose
-   * - :role:`ldm`
-     - Link to an LDM document
-   * - :role:`lse`
-     - Link to an LSE document
-   * - :role:`lpm`
-     - Link to an LPM document
-   * - :role:`lts`
-     - Link to an LTS document
-   * - :role:`lep`
-     - Link to an LEP document
-   * - :role:`lca`
-     - Link to an LCA document
-   * - :role:`lcr`
-     - Link to an LCR document
-   * - :role:`lso`
-     - Link to an LSO document
-   * - :role:`dmtr`
-     - Link to a DMTR document
-   * - :role:`sqr`
-     - Link to a SQR document
-   * - :role:`smtn`
-     - Link to a SMTN document
-   * - :role:`document`
-     - Link to a DocuShare "Document" handle
-   * - :role:`report`
-     - Link to a DocuShare "Report" handle
-   * - :role:`minutes`
-     - Link to a DocuShare "Minutes" handle
+
    * - :role:`collection`
      - Link to a DocuShare "Collection" handle
+   * - :role:`ittn`
+     - Link to an ITTN technical note
+   * - :role:`dmtn`
+     - Link to a DMTN technical note
+   * - :role:`dmtr`
+     - Link to a DMTR document
+   * - :role:`document`
+     - Link to a DocuShare "Document" handle
+   * - :role:`lca`
+     - Link to an LCA document
+   * - :role:`lcn`
+     - Link to an LCN document
+   * - :role:`lcr`
+     - Link to an LCR document
+   * - :role:`ldm`
+     - Link to an LDM document
+   * - :role:`lep`
+     - Link to an LEP document
+   * - :role:`lpm`
+     - Link to an LPM document
+   * - :role:`lse`
+     - Link to an LSE document
+   * - :role:`lsstc`
+     - Link to an LSSTC document
+   * - :role:`lso`
+     - Link to an LSO document
+   * - :role:`lts`
+     - Link to an LTS document
+   * - :role:`minutes`
+     - Link to a DocuShare "Minutes" handle
+   * - :role:`pstn`
+     - Link to a PSTN technical note
+   * - :role:`rtn`
+     - Link to an RTN technical note
+   * - :role:`sitcomtn`
+     - Link to a SITCOMTN technical note
+   * - :role:`smtn`
+     - Link to a SMTN technical note
+   * - :role:`sqr`
+     - Link to a SQR technical note
+   * - :role:`report`
+     - Link to a DocuShare "Report" handle
 
 Roles
 =====
 
-.. role:: ldm
+Links DocuShare
+---------------
 
-   Link to an LDM document:
+.. role:: collection
 
-   .. code-block:: rst
-
-      :ldm:`294`
-
-   Output: :ldm:`294`
-
-.. role:: lse
-
-   Link to an LSE document:
-
-   .. code-block:: rst
-
-      :lse:`160`
-
-   Output: :lse:`160`
-
-.. role:: lpm
-
-   Link to an LPM document:
-
-   .. code-block:: rst
-
-      :lpm:`51`
-
-   Output: :lpm:`51`
-
-.. role:: lts
-
-   Link to an LTS document:
-
-   .. code-block:: rst
-
-      :lts:`488`
-
-   Output: :lts:`488`
-
-.. role:: lep
-
-   Link to an LEP document:
-
-   .. code-block:: rst
-
-      :lep:`031`
-
-   Output: :lep:`031`
-
-.. role:: lca
-
-   Link to an LCA document:
-
-   .. code-block:: rst
-
-      :lca:`227`
-
-   Output: :lca:`227`
-
-.. role:: lsstc
-
-   Link to an LSSTC document.
-
-.. role:: lcr
-
-   Link to an LCR document.
-
-.. role:: lcn
-
-   Link to an LCN document.
-
-.. role:: lso
-
-   Link to an LSO document:
-
-   .. code-block:: rst
-
-      :lso:`011`
-
-   Output: :lso:`011`
+   Link to a DocuShare "Collection" handle.
 
 .. role:: dmtr
 
@@ -147,15 +87,102 @@ Roles
 
    Output: :dmtr:`141`
 
-.. role:: sqr
+.. role:: document
 
-   Link to a SQR document:
+   Link to a DocuShare "Document" handle.
+
+.. role:: lca
+
+   Link to an LCA document:
 
    .. code-block:: rst
 
-      :sqr:`000`
+      :lca:`227`
 
-   Output: :sqr:`000`
+   Output: :lca:`227`
+
+.. role:: lcn
+
+   Link to an LCN document.
+
+.. role:: lcr
+
+   Link to an LCR document.
+
+.. role:: ldm
+
+   Link to an LDM document:
+
+   .. code-block:: rst
+
+      :ldm:`294`
+
+   Output: :ldm:`294`
+
+.. role:: lep
+
+   Link to an LEP document:
+
+   .. code-block:: rst
+
+      :lep:`031`
+
+   Output: :lep:`031`
+
+.. role:: lpm
+
+   Link to an LPM document:
+
+   .. code-block:: rst
+
+      :lpm:`51`
+
+   Output: :lpm:`51`
+
+.. role:: lse
+
+   Link to an LSE document:
+
+   .. code-block:: rst
+
+      :lse:`160`
+
+   Output: :lse:`160`
+
+.. role:: lsstc
+
+   Link to an LSSTC document.
+
+.. role:: lso
+
+   Link to an LSO document:
+
+   .. code-block:: rst
+
+      :lso:`011`
+
+   Output: :lso:`011`
+
+.. role:: lts
+
+   Link to an LTS document:
+
+   .. code-block:: rst
+
+      :lts:`488`
+
+   Output: :lts:`488`
+
+.. role:: minutes
+
+   Link to a DocuShare "Minutes" handle.
+
+.. role:: report
+
+   Link to a DocuShare "Report" handle.
+
+Links to technical notes on lsst.io
+-----------------------------------
 
 .. role:: dmtn
 
@@ -167,6 +194,46 @@ Roles
 
    Output: :dmtn:`000`
 
+.. role:: ittn
+
+   Link to an ITTN document:
+
+   .. code-block:: rst
+
+      :ittn:`001`
+
+   Output: :ittn:`001`
+
+.. role:: pstn
+
+   Link to a PSTN document:
+
+   .. code-block:: rst
+
+      :pstn:`001`
+
+   Output: :pstn:`001`
+
+.. role:: rtn
+
+   Link to an RTN document:
+
+   .. code-block:: rst
+
+      :rtn:`001`
+
+   Output: :rtn:`001`
+
+.. role:: sitcomtn
+
+   Link to a SITCOMTN document:
+
+   .. code-block:: rst
+
+      :sitcomtn:`001`
+
+   Output: :sitcomtn:`001`
+
 .. role:: smtn
 
    Link to a SMTN document:
@@ -177,18 +244,12 @@ Roles
 
    Output: :smtn:`001`
 
-.. role:: document
+.. role:: sqr
 
-   Link to a DocuShare "Document" handle.
+   Link to a SQR document:
 
-.. role:: report
+   .. code-block:: rst
 
-   Link to a DocuShare "Report" handle.
+      :sqr:`000`
 
-.. role:: minutes
-
-   Link to a DocuShare "Minutes" handle.
-
-.. role:: collection
-
-   Link to a DocuShare "Collection" handle.
+   Output: :sqr:`000`

--- a/docs/technotes/configuration.rst
+++ b/docs/technotes/configuration.rst
@@ -74,4 +74,4 @@ Remember that if an additional package needs to be installed, add that dependenc
 Configuration source reference
 ==============================
 
-.. literalinclude:: ../../documenteer/conf/technote.py
+.. literalinclude:: ../../src/documenteer/conf/technote.py

--- a/src/documenteer/sphinxext/lsstdocushare.py
+++ b/src/documenteer/sphinxext/lsstdocushare.py
@@ -1,11 +1,26 @@
-"""LSST DocuShare/ls.st reference roles."""
+"""LSST LSST the Docs and DocuShare/ls.st reference roles."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from docutils import nodes
 
+if TYPE_CHECKING:
+    from docutils.nodes import Node, system_message
+    from docutils.parsers.rst.states import Inliner
+    from sphinx.application import Sphinx
+
 
 def lsst_doc_shortlink_role(
-    name, rawtext, text, lineno, inliner, options=None, content=None
-):
+    name: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: Optional[Dict] = None,
+    content: Optional[List[str]] = None,
+) -> Tuple[List[Node], List[system_message]]:
     """Link to LSST documents given their handle using LSST's ls.st link
     shortener.
 
@@ -24,8 +39,14 @@ def lsst_doc_shortlink_role(
 
 
 def lsst_doc_shortlink_titlecase_display_role(
-    name, rawtext, text, lineno, inliner, options=None, content=None
-):
+    name: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: Optional[Dict] = None,
+    content: Optional[List[str]] = None,
+) -> Tuple[List[Node], List[system_message]]:
     """Link to LSST documents given their handle using LSST's ls.st link
     shortener with the document handle displayed in title case.
 
@@ -46,7 +67,7 @@ def lsst_doc_shortlink_titlecase_display_role(
     return [node], []
 
 
-def setup(app):
+def setup(app: Sphinx) -> None:
     # LSST Data Management
     app.add_role("ldm", lsst_doc_shortlink_role)
     # LSST Systems Engineering

--- a/src/documenteer/sphinxext/lsstdocushare.py
+++ b/src/documenteer/sphinxext/lsstdocushare.py
@@ -133,3 +133,11 @@ def setup(app: Sphinx) -> None:
     app.add_role("dmtn", lsstio_doc_shortlink_role)
     # LSST Simulations Technical Note
     app.add_role("smtn", lsstio_doc_shortlink_role)
+    # SITCOMTN Technical Note
+    app.add_role("sitcomtn", lsstio_doc_shortlink_role)
+    # PST Technical Note
+    app.add_role("pstn", lsstio_doc_shortlink_role)
+    # Rubin Technical Note
+    app.add_role("rtn", lsstio_doc_shortlink_role)
+    # IT Technical Note
+    app.add_role("ittn", lsstio_doc_shortlink_role)

--- a/src/documenteer/sphinxext/lsstdocushare.py
+++ b/src/documenteer/sphinxext/lsstdocushare.py
@@ -12,6 +12,32 @@ if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
 
+def lsstio_doc_shortlink_role(
+    name: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: Optional[Dict] = None,
+    content: Optional[List[str]] = None,
+) -> Tuple[List[Node], List[system_message]]:
+    """Link to LSST documents given their handle that are hosted on
+    lsst.io (Rubin's deployment of LSST the Docs).
+
+    Example::
+
+        :sqr:`001`
+    """
+    options = options or {}
+    content = content or []
+    node = nodes.reference(
+        text="{0}-{1}".format(name.upper(), text),
+        refuri="https://{0}-{1}.lsst.io/".format(name.lower(), text),
+        **options,
+    )
+    return [node], []
+
+
 def lsst_doc_shortlink_role(
     name: str,
     rawtext: str,
@@ -98,9 +124,12 @@ def setup(app: Sphinx) -> None:
     app.add_role("minutes", lsst_doc_shortlink_titlecase_display_role)
     # DocuShare collection
     app.add_role("collection", lsst_doc_shortlink_titlecase_display_role)
+
+    # Technical notes are hosted canonically on www.lsst.io
+
     # LSST SQuaRE Technical Note
-    app.add_role("sqr", lsst_doc_shortlink_role)
+    app.add_role("sqr", lsstio_doc_shortlink_role)
     # LSST Data Management Technical Note
-    app.add_role("dmtn", lsst_doc_shortlink_role)
+    app.add_role("dmtn", lsstio_doc_shortlink_role)
     # LSST Simulations Technical Note
-    app.add_role("smtn", lsst_doc_shortlink_role)
+    app.add_role("smtn", lsstio_doc_shortlink_role)

--- a/tests/test_sphinxext_lsstdocushare.py
+++ b/tests/test_sphinxext_lsstdocushare.py
@@ -56,6 +56,24 @@ def inliner(app):
 @pytest.mark.parametrize(
     "test_input,expected",
     [
+        (("sqr", "123"), ("SQR-123", "https://sqr-123.lsst.io/")),
+        (("dmtn", "123"), ("DMTN-123", "https://dmtn-123.lsst.io/")),
+    ],
+)
+def test_lsstio_link(inliner, test_input, expected):
+    """Test link names and URL for technotes on lsst.io."""
+    name, content = test_input
+    result = lsstdocushare.lsstio_doc_shortlink_role(
+        name=name, rawtext=content, text=content, inliner=inliner, lineno=None
+    )
+    expected_text, expected_uri = expected
+    assert result[0][0].astext() == expected_text
+    assert result[0][0].attributes["refuri"] == expected_uri
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
         (("ldm", "151"), ("LDM-151", "https://ls.st/ldm-151")),
         (("lse", "123"), ("LSE-123", "https://ls.st/lse-123")),
         (("lpm", "123"), ("LPM-123", "https://ls.st/lpm-123")),
@@ -65,8 +83,6 @@ def inliner(app):
         (("lcr", "123"), ("LCR-123", "https://ls.st/lcr-123")),
         (("lcn", "123"), ("LCN-123", "https://ls.st/lcn-123")),
         (("dmtr", "123"), ("DMTR-123", "https://ls.st/dmtr-123")),
-        (("sqr", "123"), ("SQR-123", "https://ls.st/sqr-123")),
-        (("dmtn", "123"), ("DMTN-123", "https://ls.st/dmtn-123")),
     ],
 )
 def test_shortlink(inliner, test_input, expected):


### PR DESCRIPTION
- Add new roles
  - sitcomtn
  - rtn
  - pstn
  - ittn
- Add typing to the lsstdocushare extension
- Start trialling napoleon with sphinx_autodoc_typhints for generating the API reference