### PR TITLE
DM-34954: Change pins to use Sphinx 1.8 and numpydoc 1.2 for Documenteer 0.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.5.11 (2022-05-25)
+-------------------
+
+- Pin numpydoc < 1.3 to allow use of numpydoc 1.2 that is compatible with Python 3.10.
+
+- Pin sphinx < 2, to allow Sphinx 1.8 that is needed by numpydoc 1.2
+
 0.5.10 (2022-03-29)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ long_description = read('README.rst')
 
 # Core dependencies
 install_requires = [
-    'Sphinx>=1.7.0,<1.8.0',
+    'Sphinx<2',
     'docutils<0.18',
     'PyYAML',
     'sphinx-prompt',
@@ -53,7 +53,7 @@ extras_require = {
     # For the pipelines.lsst.io documentation project
     'pipelines': [
         'lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0',
-        'numpydoc>=0.8.0,<0.9.0',
+        'numpydoc<1.3.0',
         'sphinx-automodapi>=0.7,<0.8',
         'breathe==4.4.0',
         'sphinx-jinja==1.1.0',


### PR DESCRIPTION
The change in dependency pins to use numpydoc 1.2 principally fixes a numpydoc 0.8 incompatibility with Python 3.10. The move to Sphinx 1.8 is needed by numpydoc 1.2.

This is a release for Documenteer 0.5; new versions of Documenteer use the most recent Python versions.