### PR TITLE
DM-35768: Fix the Edit on GitHub link for documenteer.conf.technote.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.6.13 (2022-07-29)
+-------------------
+
+- Fixed the "Edit on GitHub" URL string construction in ``documenteer.conf.technote``.
+
 0.6.12 (2022-07-04)
 -------------------
 

--- a/src/documenteer/conf/technote.py
+++ b/src/documenteer/conf/technote.py
@@ -138,7 +138,7 @@ else:
 if _github_url is not None:
     if not _github_url.endswith("/"):
         _github_url = _github_url + "/"
-    _edit_url = "{_github_url}blob/{_git_branch}/index.rst"
+    _edit_url = f"{_github_url}blob/{_git_branch}/index.rst"
 else:
     _github_url = None
     _edit_url = None


### PR DESCRIPTION
Fixed the "Edit on GitHub" URL string construction in `documenteer.conf.technote`.