### PR TITLE
DM-35900: Update flake8 linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         additional_dependencies: [black==20.8b1]
         args: [-l, '79', -t, py38]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8

--- a/src/documenteer/sphinxext/lssttasks/crossrefs.py
+++ b/src/documenteer/sphinxext/lssttasks/crossrefs.py
@@ -225,8 +225,9 @@ def config_ref_role(
 
 
 def process_pending_config_xref_nodes(app, doctree, fromdocname):
-    """Process the ``pending_config_xref`` nodes during the ``doctree-resolved``
-    event to insert links to the locations of ``lsst-config-topic`` directives.
+    """Process the ``pending_config_xref`` nodes during the
+    ``doctree-resolved`` event to insert links to the locations of
+    ``lsst-config-topic`` directives.
 
     See also
     --------


### PR DESCRIPTION
This updates the URL for the flake8 pre-commit hook (from GitLab to GitHub) and solves a flake8 issue that somehow got through all this time.