### PR TITLE
DM-35917: Protect imports against CmdLineTask not being available

### DIFF
--- a/src/documenteer/sphinxext/lssttasks/topics.py
+++ b/src/documenteer/sphinxext/lssttasks/topics.py
@@ -131,12 +131,19 @@ class TaskTopicDirective(BaseTopicDirective):
     """
 
     def get_type(self, class_name):
-        from lsst.pipe.base import CmdLineTask, PipelineTask
+        try:
+            from lsst.pipe.base import CmdLineTask
+        except ImportError:
+            CmdLineTask = None
+        try:
+            from lsst.pipe.base import PipelineTask
+        except ImportError:
+            PipelineTask = None
 
         obj = get_type(class_name)
-        if issubclass(obj, PipelineTask):
+        if PipelineTask is not None and issubclass(obj, PipelineTask):
             return "PipelineTask"
-        elif issubclass(obj, CmdLineTask):
+        elif CmdLineTask is not None and issubclass(obj, CmdLineTask):
             return "CmdLineTask"
         else:
             return "Task"


### PR DESCRIPTION
`CmdLineTask` is being removed from pipe_base so will not be available in the future.

@jonathansick this is an interim fix that lets us handle the transition. I don't know if you intend to remove CmdLineTask support at some point in the future but this should fix the immediate problem I'm having with DM-35917.