### PR TITLE
DM-35917: Back port of CmdLineTask deprecation support for 0.5.12 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.5.12 (2022-08-24)
+-------------------
+
+- The ``lsst-task-topic`` directive handles new versions of LSST Science Pipelines' ``lsst.pipe.base`` where ``CmdLineTask`` is not available.
+
 0.5.11 (2022-05-25)
 -------------------
 

--- a/documenteer/sphinxext/lssttasks/topics.py
+++ b/documenteer/sphinxext/lssttasks/topics.py
@@ -131,11 +131,19 @@ class TaskTopicDirective(BaseTopicDirective):
     """
 
     def get_type(self, class_name):
-        from lsst.pipe.base import CmdLineTask, PipelineTask
+        try:
+            from lsst.pipe.base import CmdLineTask
+        except ImportError:
+            CmdLineTask = None
+        try:
+            from lsst.pipe.base import PipelineTask
+        except ImportError:
+            PipelineTask = None
+
         obj = get_type(class_name)
-        if issubclass(obj, PipelineTask):
+        if PipelineTask is not None and issubclass(obj, PipelineTask):
             return 'PipelineTask'
-        elif issubclass(obj, CmdLineTask):
+        elif CmdLineTask is not None and issubclass(obj, CmdLineTask):
             return 'CmdLineTask'
         else:
             return 'Task'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,2 @@
 [aliases]
 test=pytest
-
-[flake8]
-max-line-length = 79
-
-[tool:pytest]
-addopts = --flake8 --cov=documenteer

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ extras_require = {
         'wheel',
         'twine',
         'pytest',
-        'pytest-cov',
-        'pytest-flake8',
         'pytest-mock',
         # Extensions for documenteer's own docs. Perhaps add this to main
         # installation for other projects?


### PR DESCRIPTION
This backports #126 to the 0.5 release series.