### PR TITLE
DM-35917: Back port CmdLineTask deprecation support for 0.6 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+0.6.14 (2022-08-24)
+-------------------
+
+- The ``lsst-task-topic`` directive handles new versions of LSST Science Pipelines' ``lsst.pipe.base`` where ``CmdLineTask`` is not available.
+
 0.6.13 (2022-07-29)
 -------------------
 

--- a/src/documenteer/sphinxext/lssttasks/topics.py
+++ b/src/documenteer/sphinxext/lssttasks/topics.py
@@ -131,12 +131,19 @@ class TaskTopicDirective(BaseTopicDirective):
     """
 
     def get_type(self, class_name):
-        from lsst.pipe.base import CmdLineTask, PipelineTask
+        try:
+            from lsst.pipe.base import CmdLineTask
+        except ImportError:
+            CmdLineTask = None
+        try:
+            from lsst.pipe.base import PipelineTask
+        except ImportError:
+            PipelineTask = None
 
         obj = get_type(class_name)
-        if issubclass(obj, PipelineTask):
+        if PipelineTask is not None and issubclass(obj, PipelineTask):
             return "PipelineTask"
-        elif issubclass(obj, CmdLineTask):
+        elif CmdLineTask is not None and issubclass(obj, CmdLineTask):
             return "CmdLineTask"
         else:
             return "Task"


### PR DESCRIPTION
This backports #126 to the 0.6 release series.