### PR TITLE
DM-36137: Support setting extensions, linkcheck and nitpick settings in documenteer.toml

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -37,6 +37,7 @@
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://pytest.org
 .. _toctree: http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree
+.. _linkcheck: https://www.sphinx-doc.org/en/master/usage/configuration.html?#options-for-the-linkcheck-builder
 
 .. Internal links
 

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -32,7 +32,6 @@
 .. _breathe: http://breathe.readthedocs.io/en/latest/index.html
 .. _conda-forge: https://conda-forge.org
 .. _conda: https://conda.io/en/latest/index.html
-.. _doxylink: https://pythonhosted.org/sphinxcontrib-doxylink/
 .. _isort: https://pycqa.github.io/isort/
 .. _numpydoc: https://numpydoc.readthedocs.io/en/latest/index.html
 .. _pre-commit: https://pre-commit.com

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,5 @@
 from documenteer.conf.guide import *
 
-# Intersphinx
-
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "requests": ("https://requests.readthedocs.io/en/latest/", None),
-    "developer": ("https://developer.lsst.io/", None),
-    "pybtex": ("https://docs.pybtex.org/", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-}
-
 # Warnings to ignore
 nitpick_ignore = [
     # This link to the base pybtex still never resolves because it is not

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,5 @@
 from documenteer.conf.guide import *
 
-# Warnings to ignore
-nitpick_ignore = [
-    # This link to the base pybtex still never resolves because it is not
-    # in pybtex's intersphinx'd API reference.
-    ("py:class", "pybtex.style.formatting.plain.Style"),
-]
-
 # Automodapi
 # https://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html
 automodapi_toctreedirnm = "dev/api/contents"

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -9,6 +9,14 @@ package = "documenteer"
 
 [sphinx]
 rst_epilog_file = "_rst_epilog.rst"
+nitpick_ignore = [
+  ["py:class", "pybtex.style.formatting.plain.Style"],
+  ["py:obj", "sphinx_automodapi.automodapi"],
+]
+nitpick_ignore_regex = [
+  ['py:.*', 'docutils.*'],
+  ['py:.*', 'pydantic.*'],
+]
 
 [sphinx.intersphinx.projects]
 python = "https://docs.python.org/3/"

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -9,6 +9,7 @@ package = "documenteer"
 
 [sphinx]
 rst_epilog_file = "_rst_epilog.rst"
+nitpicky = true
 nitpick_ignore = [
   ["py:class", "pybtex.style.formatting.plain.Style"],
   ["py:obj", "sphinx_automodapi.automodapi"],

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -9,3 +9,10 @@ package = "documenteer"
 
 [sphinx]
 rst_epilog_file = "_rst_epilog.rst"
+
+[sphinx.intersphinx.projects]
+python = "https://docs.python.org/3/"
+requests = "https://requests.readthedocs.io/en/latest/"
+developer = "https://developer.lsst.io/"
+pybtex = "https://docs.pybtex.org/"
+sphinx = "https://www.sphinx-doc.org/en/master/"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Documenteer
 This documentation is for version |version|. `Find docs for other versions. <https://documenteer.lsst.io/v>`__
 Documenteer is developed on GitHub at https://github.com/lsst-sqre/documenteer.
 
+.. _pip-install:
 .. _installation:
 
 Installation

--- a/docs/project-guides/guides/extend-conf-py.rst
+++ b/docs/project-guides/guides/extend-conf-py.rst
@@ -30,18 +30,3 @@ To additionally add the LSST Science Pipelines:
    from documenteer.conf.guide import *
 
    intersphinx_mapping["python"] = ("https://pipelines.lsst.io", None)
-
-Adding a Sphinx extension
--------------------------
-
-You can add additional `Sphinx extensions`_ to your Sphinx build to make use of custom reStructuredText directives and roles.
-To add a new extension, append to the ``extensions`` list:
-
-.. code-block:: python
-   :caption: conf.py
-
-   from documenteer.conf.guide import *
-
-   extensions.extend(["sphinx-click"])
-
-Remember that additional packages may need to be added to your project's Python dependencies (such as in a ``requirements.txt`` or ``pyproject.toml`` file).

--- a/docs/project-guides/guides/extend-conf-py.rst
+++ b/docs/project-guides/guides/extend-conf-py.rst
@@ -6,27 +6,29 @@ The basic configurations, through :file:`documenteer.toml` and |documenteer.conf
 You will likely need to extend that configuration, though.
 This page describes a few common scenarios.
 
-In general, structure your customizations so that they add to the configuration presets from |documenteer.conf.guide|.
-If the configuration variable is a list or a dictionary, try to append to that list or dictionary rather than reassigning the whole variable.
+Using the [sphinx] table in documenteer.toml
+============================================
 
-Adding a package to Intersphinx
--------------------------------
+Before editing :file:`conf.py`, check the :doc:`toml-reference` to see if there's support for a particular Sphinx configuration.
+For example, the ``[sphinx]`` table includes support for adding Sphinx extensions, adding projects to the Intersphinx_ mapping, among other capabilities.
 
-One scenario is adding additional projects to the Intersphinx_ configuration.
-For example, to add the Python standard library so that built-in Python APIs can be referenced:
+If the configuration isn't supported by :file:`documenteer.toml`, you can edit the Sphinx :file:`conf.py` configuration file directly.
+
+Editing conf.py
+===============
+
+When Sphinx runs, the :file:`conf.py` configuration file is "executed" so that all variables in the global namespace become Sphinx configurations.
+The |documenteer.conf.guide| configuration presets populate the global namespace.
+Therefore you can add or edit those configurations by setting variables after the import of |documenteer.conf.guide|.
+
+For example, to change the number of times the linkcheck builder will try a URL:
 
 .. code-block:: python
    :caption: conf.py
 
    from documenteer.conf.guide import *
 
-   intersphinx_mapping["python"] = ("https://docs.python.org/3", None)
+   linkcheck_retries = 2
 
-To additionally add the LSST Science Pipelines:
-
-.. code-block:: python
-   :caption: conf.py
-
-   from documenteer.conf.guide import *
-
-   intersphinx_mapping["python"] = ("https://pipelines.lsst.io", None)
+See the `list of Sphinx configuration in the Sphinx documentation <https://www.sphinx-doc.org/en/master/usage/configuration.html>`__.
+Extensions can also declare additional configurations, see their documentation for listings.

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -141,6 +141,54 @@ Duplicate extensions are ignored.
 
 Remember that additional packages may need to be added to your project's Python dependencies (such as in a ``requirements.txt`` or ``pyproject.toml`` file).
 
+nitpick_ignore
+--------------
+
+|optional|
+
+A list of Sphinx warnings to ignore.
+Each item is a tuple of two items:
+
+1. ``type``, often the reStructuredText role or directive creating the error/warning.
+2. ``target``, often the argument to the reStructuredText role.
+
+.. code-block:: toml
+
+   [sphinx]
+   nitpick_ignore = [
+     ["py:class", "fastapi.applications.FastAPI"],
+     ["py:class", "httpx.AsyncClient"],
+     ["py:class", "pydantic.main.BaseModel"],
+   ]
+
+This configuration extends the Sphinx ``nitpick_ignore`` configuration.
+
+nitpick_ignore_regex
+--------------------
+
+|optional|
+
+A list of Sphinx warnings to ignore, formatted as regular expressions.
+Each item is a tuple of two items:
+
+1. ``type``, a regular expression of the warning type.
+2. ``target``, a regular expression of the warning target.
+
+.. code-block:: toml
+
+   [sphinx]
+   nitpick_ignore_regex = [
+     ['py:.*', 'fastapi.*'],
+     ['py:.*', 'httpx.*'],
+     ['py:.*', 'pydantic*'],
+   ]
+
+.. tip::
+
+   Use single quotes for literal strings in TOML.
+
+This configuration extends the Sphinx ``nitpick_ignore_regex`` configuration.
+
 rst_epilog_file
 ---------------
 

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -141,6 +141,21 @@ Duplicate extensions are ignored.
 
 Remember that additional packages may need to be added to your project's Python dependencies (such as in a ``requirements.txt`` or ``pyproject.toml`` file).
 
+nitpicky
+--------
+
+|optional|
+
+Set to ``true`` to escalate Sphinx warnings to errors, which is useful for leveraging CI to notify you of any syntax errors.
+The default is ``false``.
+
+.. code-block:: toml
+
+   [sphinx]
+   nitpicky = true
+
+See ``nitpick_ignore`` and ``nitpick_ignore_regex`` for ways to suppress unavoidable errors.
+
 nitpick_ignore
 --------------
 

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -188,3 +188,18 @@ The values are URLs to the root of Sphinx documentation projects.
    python = "https://docs.python.org/3/"
 
 See the Intersphinx_ documentation for details on linking to other Sphinx projects.
+
+[sphinx.linkcheck]
+==================
+
+|optional|
+
+Configurations related to Sphinx's linkcheck_ builder.
+
+ignore
+------
+
+|optional|
+
+List of URL regular expressions patterns to ignore checking.
+These are appended to the ``linkcheck_ignore`` configuration.

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -163,3 +163,28 @@ If set, the file is also included in the Sphinx source ignore list to prevent it
 
    .. |required| replace:: :bdg-primary-line:`Required`
    .. |optional| replace:: :bdg-secondary-line:`Optional`
+
+[sphinx.intersphinx]
+====================
+
+|optional|
+
+Configurations related to Intersphinx_ for linking to other Sphinx projects.
+
+[sphinx.intersphinx.projects]
+=============================
+
+|optional|
+
+A table of Sphinx projects.
+The labels are targets for the :external+sphinx:rst:role:`external` role.
+The values are URLs to the root of Sphinx documentation projects.
+
+.. code-block:: toml
+
+   [sphinx.intersphinx.projects]
+   sphinx = "https://www.sphinx-doc.org/en/master/"
+   documenteer = "https://documenteer.lsst.io"
+   python = "https://docs.python.org/3/"
+
+See the Intersphinx_ documentation for details on linking to other Sphinx projects.

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -131,6 +131,16 @@ If your GitHub repository's URL is associated with a different field label, set 
 
 This ``[sphinx]`` table allows you to set a number of Sphinx configurations that you would normally set through the :file:`conf.py` file.
 
+extensions
+----------
+
+|optional|
+
+A list of Sphinx extensions to append to the extensions included in the Documenteer configuration preset (see |documenteer.conf.guide|).
+Duplicate extensions are ignored.
+
+Remember that additional packages may need to be added to your project's Python dependencies (such as in a ``requirements.txt`` or ``pyproject.toml`` file).
+
 rst_epilog_file
 ---------------
 

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -108,6 +108,15 @@ class IntersphinxModel(BaseModel):
     )
 
 
+class LinkCheckModel(BaseModel):
+    """Model for linkcheck builder configurations in documenteer.toml."""
+
+    ignore: List[str] = Field(
+        description="Regular expressions of URLs to skip checking links",
+        default_factory=list,
+    )
+
+
 class SphinxModel(BaseModel):
     """Model for Sphinx configurations in documenteer.toml."""
 
@@ -123,6 +132,8 @@ class SphinxModel(BaseModel):
     )
 
     intersphinx: Optional[IntersphinxModel]
+
+    linkcheck: Optional[LinkCheckModel]
 
 
 class ConfigRoot(BaseModel):
@@ -295,3 +306,10 @@ class DocumenteerConfig:
         ):
             for project, url in self.conf.sphinx.intersphinx.projects.items():
                 mapping[project] = (str(url), None)
+
+    def append_linkcheck_ignore(self, link_patterns: List[str]) -> None:
+        """Append URL patterns for sphinx.linkcheck.ignore to existing
+        patterns.
+        """
+        if self.conf.sphinx and self.conf.sphinx.linkcheck:
+            link_patterns.extend(self.conf.sphinx.linkcheck.ignore)

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -199,7 +199,7 @@ class DocumenteerConfig:
 
         1. The ``base_url`` field of the ``[project]`` table in
            documenteer.toml.
-        2. From importlib.metadata if `[project.python]` is set in
+        2. From importlib.metadata if ``[project.python]`` is set in
            documenteer.toml.
         3. Default is "".
         """

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -131,6 +131,23 @@ class SphinxModel(BaseModel):
         description="Additional Sphinx extension.", default_factory=list
     )
 
+    nitpick_ignore: List[Tuple[str, str]] = Field(
+        description=(
+            "Errors to ignore. First item is the type (like a role or "
+            "directive) and the second is the target (like the argument to "
+            "the role)."
+        ),
+        default_factory=list,
+    )
+
+    nitpick_ignore_regex: List[Tuple[str, str]] = Field(
+        description=(
+            "Same as ``nitpick_ignore``, but both type and target are "
+            "interpreted as regular expressions."
+        ),
+        default_factory=list,
+    )
+
     intersphinx: Optional[IntersphinxModel]
 
     linkcheck: Optional[LinkCheckModel]
@@ -313,3 +330,15 @@ class DocumenteerConfig:
         """
         if self.conf.sphinx and self.conf.sphinx.linkcheck:
             link_patterns.extend(self.conf.sphinx.linkcheck.ignore)
+
+    def append_nitpick_ignore(
+        self, nitpick_ignore: List[Tuple[str, str]]
+    ) -> None:
+        if self.conf.sphinx and self.conf.sphinx.nitpick_ignore:
+            nitpick_ignore.extend(self.conf.sphinx.nitpick_ignore)
+
+    def append_nitpick_ignore_regex(
+        self, nitpick_ignore_regex: List[Tuple[str, str]]
+    ) -> None:
+        if self.conf.sphinx and self.conf.sphinx.nitpick_ignore_regex:
+            nitpick_ignore_regex.extend(self.conf.sphinx.nitpick_ignore_regex)

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -131,6 +131,10 @@ class SphinxModel(BaseModel):
         description="Additional Sphinx extension.", default_factory=list
     )
 
+    nitpicky: bool = Field(
+        False, description="Escalate warnings to build errors."
+    )
+
     nitpick_ignore: List[Tuple[str, str]] = Field(
         description=(
             "Errors to ignore. First item is the type (like a role or "
@@ -342,3 +346,10 @@ class DocumenteerConfig:
     ) -> None:
         if self.conf.sphinx and self.conf.sphinx.nitpick_ignore_regex:
             nitpick_ignore_regex.extend(self.conf.sphinx.nitpick_ignore_regex)
+
+    @property
+    def nitpicky(self) -> bool:
+        if self.conf.sphinx:
+            return self.conf.sphinx.nitpicky
+        else:
+            return False

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass
 from email.message import Message
-from typing import Optional, cast
+from typing import List, Optional, cast
 
 if sys.version_info < (3, 8):
     from importlib_metadata import PackageNotFoundError, metadata
@@ -108,6 +108,10 @@ class SphinxModel(BaseModel):
             "Path to a reStructuredText file that is added to every source "
             "file. Use this file to define common links and substitutions."
         )
+    )
+
+    extensions: List[str] = Field(
+        description="Additional Sphinx extension.", default_factory=list
     )
 
 
@@ -260,3 +264,10 @@ class DocumenteerConfig:
                 if value.startswith(prefix):
                     return value[len(prefix) :]
         return None
+
+    def append_extensions(self, extensions: List[str]) -> None:
+        """Append user-configured extensions to an existing list."""
+        if self.conf.sphinx:
+            for new_ext in self.conf.sphinx.extensions:
+                if new_ext not in extensions:
+                    extensions.append(new_ext)

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -184,6 +184,7 @@ linkcheck_ignore = [
     r"^https://jira.lsstcorp.org/browse/",
     r"^https://ls.st/",
 ]
+_conf.append_linkcheck_ignore(linkcheck_ignore)
 
 linkcheck_timeout = 15
 

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -47,6 +47,7 @@ __all__ = [
     "language",
     "exclude_patterns",
     "default_role",
+    "nitpicky",
     "nitpick_ignore",
     "nitpick_ignore_regex",
     "templates_path",
@@ -149,6 +150,9 @@ if _conf.rst_epilog_path:
 
 # The reST default role cross-links Python (used for this markup: `text`)
 default_role = "py:obj"
+
+# Escalate warnings ot errors if True
+nitpicky = _conf.nitpicky
 
 # Warnings to ignore
 nitpick_ignore: List[Tuple[str, str]] = []

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -165,7 +165,8 @@ rst_epilog = _conf.rst_epilog
 
 # Example entry:
 #   "python": ("https://docs.python.org/3/", None),
-intersphinx_mapping: Dict[str, Tuple[Union[str, None]]] = {}
+intersphinx_mapping: Dict[str, Tuple[str, Union[str, None]]] = {}
+_conf.extend_intersphinx_mapping(intersphinx_mapping)
 
 intersphinx_timeout = 10.0  # seconds
 

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -114,6 +114,7 @@ extensions = [
     "sphinx_automodapi.smart_resolver",
     "documenteer.sphinxext",
 ]
+_conf.append_extensions(extensions)
 
 # ============================================================================
 # #SPHINX Core Sphinx configurations

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -48,6 +48,7 @@ __all__ = [
     "exclude_patterns",
     "default_role",
     "nitpick_ignore",
+    "nitpick_ignore_regex",
     "templates_path",
     "rst_epilog",
     # INTER
@@ -151,6 +152,10 @@ default_role = "py:obj"
 
 # Warnings to ignore
 nitpick_ignore: List[Tuple[str, str]] = []
+_conf.append_nitpick_ignore(nitpick_ignore)
+
+nitpick_ignore_regex: List[Tuple[str, str]] = []
+_conf.append_nitpick_ignore_regex(nitpick_ignore_regex)
 
 # A list of paths that contain extra templates (or templates that overwrite
 # builtin/theme-specific templates).

--- a/src/documenteer/sphinxconfig/stackconf.py
+++ b/src/documenteer/sphinxconfig/stackconf.py
@@ -435,22 +435,22 @@ def build_package_configs(
 
     Parameters
     ----------
-    project_name : str
+    project_name : `str`
         Name of the package.
-    copyright : str, optional
+    copyright : `str`, optional
         Copyright statement. Do not include the 'Copyright (c)' string; it'll
         be added automatically.
-    version : str
+    version : `str`
         Version string. Use the ``__version__`` member in a package's
         ``version`` module.
-    doxygen_xml_dirname : str
+    doxygen_xml_dirname : `str`
         Path to doxygen-generated XML, allowing C++ APIs to be documented
         through breathe. If not set, the breathe sphinx extension will not be
         enabled.
 
     Returns
     -------
-    c : dict
+    c : `dict`
         Dictionary of configurations that should be added to the ``conf.py``
         global namespace via::
 

--- a/src/documenteer/sphinxconfig/technoteconf.py
+++ b/src/documenteer/sphinxconfig/technoteconf.py
@@ -54,7 +54,7 @@ def configure_technote(meta_stream):
 
     Parameters
     ----------
-    meta_stream : file handle
+    meta_stream : `io.StringIO`
         A file stream (e.g., from :func:`open`) for the ``metadata.yaml``
         document in a design document's repository.
 

--- a/src/documenteer/sphinxrunner.py
+++ b/src/documenteer/sphinxrunner.py
@@ -20,16 +20,16 @@ def run_sphinx(
 
     Parameters
     ----------
-    root_dir
+    root_dir : `str`
         Root directory of the Sphinx project and content source. This directory
         contains both the root ``index.rst`` file and the ``conf.py``
         configuration file.
-    job_count
+    job_count : `int`
         Number of cores to run the Sphinx build with (``-j`` flag)
 
     Returns
     -------
-    status
+    status : `int`
         Sphinx status code. ``0`` is expected. Greater than ``0`` indicates
         an error.
 

--- a/src/documenteer/stackdocs/build.py
+++ b/src/documenteer/stackdocs/build.py
@@ -80,7 +80,7 @@ def build_stack_docs(
 
     Returns
     -------
-    sphinx_status
+    sphinx_status : `int`
         The shell status code for the Sphinx build. If ``enable_sphinx`` is
         ``False``, the status defaults to ``0``.
     """

--- a/src/documenteer/stackdocs/doxygen.py
+++ b/src/documenteer/stackdocs/doxygen.py
@@ -310,7 +310,7 @@ class DoxygenConfiguration:
 
         Returns
         -------
-        config_content
+        config_content : `str`
             Text content of a doxygen configuration file.
         """
         lines: List[str] = []
@@ -484,7 +484,7 @@ class DoxygenConfiguration:
 
         Returns
         -------
-        doxygen_configuration
+        doxygen_configuration : `DoxygenConfiguration`
             A DoxygenConfiguration instance populated with configurations
             parsed from ``doxygen_conf``.
 
@@ -720,7 +720,7 @@ def run_doxygen(*, conf: DoxygenConfiguration, root_dir: Path) -> int:
 
     Returns
     -------
-    status
+    status : `int`
         The shell status code returned by the ``doxygen`` executable.
     """
     os.makedirs(root_dir, exist_ok=True)

--- a/src/documenteer/stackdocs/pkgdiscovery.py
+++ b/src/documenteer/stackdocs/pkgdiscovery.py
@@ -28,13 +28,13 @@ def discover_setup_packages(
 
     Parameters
     ----------
-    scope
+    scope : `list` of `str`
         Names of packages that are in scope to include in the returned package
         data. Leave as `None` if packages should not be filtered.
 
     Returns
     -------
-    packages
+    packages : `dict`
        Dictionary with keys that are EUPS package names. Values are
        dictionaries with fields:
 
@@ -76,14 +76,14 @@ def find_table_file(root_project_dir: Union[str, Path]) -> Path:
 
     Parameters
     ----------
-    root_project_dir
+    root_project_dir : `str` or `pathlib.Path`
         Path to the root directory of the main documentation project. This
         is the directory containing the ``conf.py`` file and a ``ups``
         directory.
 
     Returns
     -------
-    table_path
+    table_path : `pathlib.Path`
         Path to the EUPS table file.
     """
     root_project_dir = Path(root_project_dir)
@@ -104,12 +104,12 @@ def list_packages_in_eups_table(table_text: str) -> List[str]:
 
     Parameters
     ----------
-    table_text
+    table_text : `str`
         The text content of an EUPS table file.
 
     Returns
     -------
-    names
+    names : `list` of `str`
         List of package names that are required byy the EUPS table file.
     """
     logger = logging.getLogger(__name__)
@@ -178,14 +178,14 @@ def find_package_docs(
 
     Parameters
     ----------
-    package_dir
+    package_dir : `str` or `pathlib.Path`
         Directory of an EUPS package.
-    skipped_names
+    skipped_names : `list` of `str`, optional
         List of package or module names to skip when creating links.
 
     Returns
     -------
-    doc_dirs
+    doc_dirs : `Package`
         Metadata about a stack package's documentation content.
 
     Raises

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -28,6 +28,11 @@ extensions = [
 sphinx = "https://www.sphinx-doc.org/en/master/"
 documenteer = "https://documenteer.lsst.io"
 python = "https://docs.python.org/3/"
+
+[sphinx.linkcheck]
+ignore = [
+    "^https://confluence.lsstcorp.org/"
+]
 """
 
 EXAMPLE_BAD_PACKAGE = """
@@ -105,3 +110,18 @@ def test_append_intersphinx_projects() -> None:
         "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
         "documenteer": ("https://documenteer.lsst.io", None),
     }
+
+
+def test_append_linkcheck_ignore() -> None:
+    config = DocumenteerConfig.load(EXAMPLE)
+
+    linkcheck_ignore = [
+        r"^https://jira.lsstcorp.org/browse/",
+        r"^https://ls.st/",
+    ]
+    config.append_linkcheck_ignore(linkcheck_ignore)
+    assert linkcheck_ignore == [
+        r"^https://jira.lsstcorp.org/browse/",
+        r"^https://ls.st/",
+        r"^https://confluence.lsstcorp.org/",
+    ]

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Dict, Tuple, Union
+
 import pytest
 from sphinx.errors import ConfigError
 
@@ -21,6 +23,11 @@ extensions = [
     "sphinx_design",
     "new_extension",
 ]
+
+[sphinx.intersphinx.projects]
+sphinx = "https://www.sphinx-doc.org/en/master/"
+documenteer = "https://documenteer.lsst.io"
+python = "https://docs.python.org/3/"
 """
 
 EXAMPLE_BAD_PACKAGE = """
@@ -84,3 +91,17 @@ def test_append_extensions() -> None:
         "documenteer.sphinxext",
         "new_extension",
     ]
+
+
+def test_append_intersphinx_projects() -> None:
+    config = DocumenteerConfig.load(EXAMPLE)
+
+    projects: Dict[str, Tuple[str, Union[str, None]]] = {
+        "python": ("https://docs.python.org/3/", None),
+    }
+    config.extend_intersphinx_mapping(projects)
+    assert projects == {
+        "python": ("https://docs.python.org/3/", None),
+        "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+        "documenteer": ("https://documenteer.lsst.io", None),
+    }

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -15,6 +15,12 @@ base_url = "https://documenteer.lsst.io"
 copyright = "2022 AURA"
 github_url = "https://github.com/lsst-sqre/documenteer"
 version = "1.0.0"
+
+[sphinx]
+extensions = [
+    "sphinx_design",
+    "new_extension",
+]
 """
 
 EXAMPLE_BAD_PACKAGE = """
@@ -60,3 +66,21 @@ def test_python_metadata() -> None:
     assert config.copyright == "2022 AURA"
     assert config.github_url == "https://github.com/lsst-sqre/documenteer"
     assert isinstance(config.version, str)
+
+
+def test_append_extensions() -> None:
+    """Test DocumenteerConfig.append_extensions()."""
+    config = DocumenteerConfig.load(EXAMPLE)
+
+    existing_extensions = [
+        "sphinx_design",
+        "sphinx.ext.autodoc",
+        "documenteer.sphinxext",
+    ]
+    config.append_extensions(existing_extensions)
+    assert existing_extensions == [
+        "sphinx_design",
+        "sphinx.ext.autodoc",
+        "documenteer.sphinxext",
+        "new_extension",
+    ]

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -23,6 +23,12 @@ extensions = [
     "sphinx_design",
     "new_extension",
 ]
+nitpick_ignore = [
+    ["py:class", "pydantic.main.BaseModel"]
+]
+nitpick_ignore_regex = [
+    ["py:.+", 'fastapi\\..+']
+]
 
 [sphinx.intersphinx.projects]
 sphinx = "https://www.sphinx-doc.org/en/master/"


### PR DESCRIPTION
This PR adds more support for common Sphinx configurations in `documenteer.toml`:

- nitpicky
- nitpick_ignore
- nitpick_ignore_regex
- intersphinx_mapping
- extensions

As well, we've made the Documenteer docs build cleanly thanks to leveraging `nitpick_ignore_regex`.