### PR TITLE
DM-36156: Exclude click and autoprogram from guide config

### DIFF
--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -8,6 +8,10 @@ github_url = "https://github.com/lsst-sqre/documenteer"
 package = "documenteer"
 
 [sphinx]
+extensions = [
+  "sphinx_click.ext",
+  "sphinxcontrib.autoprogram",
+]
 rst_epilog_file = "_rst_epilog.rst"
 nitpicky = true
 nitpick_ignore = [

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -107,8 +107,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.ifconfig",
-    "sphinx_click.ext",
-    "sphinxcontrib.autoprogram",
     "sphinx-prompt",
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",


### PR DESCRIPTION
The sphinx_click and autoprogram extensions automatically got added to the extensions list in documenteer.conf.guide, but really they shouldn't be in the default extension list and in fact they weren't part of the original [guide] dependencies extras anyhow.