### PR TITLE
DM-36190: Enable additional features and configurations for user guides

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-from documenteer.conf.guide import *
+# See the documenteer.toml for overrides of the Rubin user guide presets
 
-# Automodapi
-# https://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html
-automodapi_toctreedirnm = "dev/api/contents"
+from documenteer.conf.guide import *

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -12,6 +12,7 @@ extensions = [
   "sphinx_click.ext",
   "sphinxcontrib.autoprogram",
 ]
+disable_primary_sidebars = ["index", "changelog"]
 rst_epilog_file = "_rst_epilog.rst"
 nitpicky = true
 nitpick_ignore = [

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -23,6 +23,7 @@ nitpick_ignore_regex = [
   ['py:.*', 'docutils.*'],
   ['py:.*', 'pydantic.*'],
 ]
+python_api_dir = "dev/api/contents"
 
 [sphinx.intersphinx.projects]
 python = "https://docs.python.org/3/"

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -131,6 +131,29 @@ If your GitHub repository's URL is associated with a different field label, set 
 
 This ``[sphinx]`` table allows you to set a number of Sphinx configurations that you would normally set through the :file:`conf.py` file.
 
+disable_primary_sidebars
+------------------------
+
+|optional|
+
+On some pages the default sidebar (on the left) is inappropriate, such as index pages that already contain a table of contents as their main content.
+In that case, you can set individual pages or globs (without extensions) of pages that are shown without
+the primary sidebar.
+The default is ``["index"]`` to remove the sidebar from the homepage.
+
+.. code-block:: toml
+
+   [sphinx]
+   disable_primary_sidebars = [
+     "**/index",
+     "changelog"
+   ]
+
+.. note::
+
+   This configuration is for the **primary** sidebar, on the left side, containing side or section-level navigation links.
+   To remove the page-level contents sidebar, on the right side, add ``:html_theme.sidebar_secondary.remove:`` to the *page's* file metadata.
+
 extensions
 ----------
 

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -250,6 +250,21 @@ If set, the file is also included in the Sphinx source ignore list to prevent it
    .. |required| replace:: :bdg-primary-line:`Required`
    .. |optional| replace:: :bdg-secondary-line:`Optional`
 
+python_api_dir
+--------------
+
+|optional|
+
+Set this to the directory where Python API documentation is generated, through automodapi_.
+The default value is ``api``, which is a good standard for Python projects with a public API.
+
+If the Python API is oriented towards contributors, such as in an application or service, you can change the default:
+
+.. code-block:: toml
+
+   [sphinx]
+   python_api_dir = "dev/api/contents"
+
 [sphinx.intersphinx]
 ====================
 

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -67,6 +67,17 @@ When set, a link to the repository is included in the site's header.
    [project]
    github_url = "https://github.com/lsst-sqre/documenteer"
 
+.. _guide-project-github-default-branch:
+
+github_default_branch
+---------------------
+
+|optional|
+
+The default branch on GitHub.
+Default is ``main``.
+Used in conjunction with the "Edit on GitHub" link, see :ref:`sphinx.show_github_edit_link <guide-project-show-github-edit-link>`.
+
 .. _guide-project-version:
 
 version
@@ -264,6 +275,27 @@ If the Python API is oriented towards contributors, such as in an application or
 
    [sphinx]
    python_api_dir = "dev/api/contents"
+
+[sphinx.theme]
+==============
+
+|optional|
+
+Configurations related to the Sphinx HTML theme.
+
+.. _guide-project-show-github-edit-link:
+
+show_github_edit_link
+---------------------
+
+|optional|
+
+Default is ``true``, so that each page contains a link to edit its source on GitHub.
+
+This configuration requires information about the GitHub repository from these other configurations:
+
+- :ref:`project.github_url <guide-project-github-url>`
+- :ref:`project.github_default_branch <guide-project-github-default-branch>`
 
 [sphinx.intersphinx]
 ====================

--- a/docs/project-guides/guides/toml-reference.rst
+++ b/docs/project-guides/guides/toml-reference.rst
@@ -283,6 +283,16 @@ If the Python API is oriented towards contributors, such as in an application or
 
 Configurations related to the Sphinx HTML theme.
 
+header_links_before_dropdown
+----------------------------
+
+|optional|
+
+Number of links to show in the navigation head before folding extra items into a "More" dropdown.
+The default is 5.
+
+If the section titles are long you may need to reduce this number.
+
 .. _guide-project-show-github-edit-link:
 
 show_github_edit_link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ guide = [
     "pydata-sphinx-theme>=0.10.0",
     "sphinx-autodoc-typehints",
     "sphinx-automodapi",
+    "sphinx-copybutton",
     "sphinx-prompt",
     "myst-parser",
     "markdown-it-py[linkify]",

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -152,6 +152,15 @@ class SphinxModel(BaseModel):
         default_factory=list,
     )
 
+    disable_primary_sidebars: Optional[List[str]] = Field(
+        None,
+        description=(
+            "Pages that should not have a primary sidebar. Can be the page's "
+            "path (without extension) or a glob of pages. By default the "
+            "homepage and change logs do not have a primary sidebar."
+        ),
+    )
+
     intersphinx: Optional[IntersphinxModel]
 
     linkcheck: Optional[LinkCheckModel]
@@ -353,3 +362,12 @@ class DocumenteerConfig:
             return self.conf.sphinx.nitpicky
         else:
             return False
+
+    def disable_primary_sidebars(
+        self, html_sidebars: MutableMapping[str, List[str]]
+    ) -> None:
+        if self.conf.sphinx and self.conf.sphinx.disable_primary_sidebars:
+            pages = self.conf.sphinx.disable_primary_sidebars
+        else:
+            pages = ["index"]  # default
+        html_sidebars.update({name: list() for name in pages})

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -141,6 +141,14 @@ class ThemeModel(BaseModel):
         True, description="Show a link to edit on GitHub if True"
     )
 
+    header_links_before_dropdown: int = Field(
+        5,
+        description=(
+            "Number of links in the header nav before showing a 'More' "
+            "dropdown."
+        ),
+    )
+
 
 class SphinxModel(BaseModel):
     """Model for Sphinx configurations in documenteer.toml."""
@@ -194,7 +202,7 @@ class SphinxModel(BaseModel):
         ),
     )
 
-    theme: ThemeModel
+    theme: ThemeModel = Field(default_factory=lambda: ThemeModel())
 
     intersphinx: Optional[IntersphinxModel]
 
@@ -463,3 +471,13 @@ class DocumenteerConfig:
             "github_version"
         ] = self.conf.project.github_default_branch
         html_context["doc_path"] = doc_dir
+
+    @property
+    def header_links_before_dropdown(self) -> int:
+        """Number of links to show in the nav head before folding extra items
+        into a More dropdown.
+        """
+        if self.conf.sphinx:
+            return self.conf.sphinx.theme.header_links_before_dropdown
+        else:
+            return 5

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -161,6 +161,14 @@ class SphinxModel(BaseModel):
         ),
     )
 
+    python_api_dir: Optional[str] = Field(
+        None,
+        description=(
+            "Directory path where the Python API reference documentation "
+            "is created."
+        ),
+    )
+
     intersphinx: Optional[IntersphinxModel]
 
     linkcheck: Optional[LinkCheckModel]
@@ -371,3 +379,10 @@ class DocumenteerConfig:
         else:
             pages = ["index"]  # default
         html_sidebars.update({name: list() for name in pages})
+
+    @property
+    def automodapi_toctreedirm(self) -> str:
+        if self.conf.sphinx and self.conf.sphinx.python_api_dir is not None:
+            return self.conf.sphinx.python_api_dir
+        else:
+            return "api"

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from git import Repo
 from sphinx.errors import ConfigError
 
-__all__ = ["get_asset_path", "get_template_dir"]
+__all__ = ["get_asset_path", "get_template_dir", "GitRepository"]
 
 
 def get_asset_path(name: str) -> str:
@@ -75,3 +76,20 @@ def get_template_dir(root: str) -> str:
             "Documenteer package."
         )
     return str(dirname)
+
+
+class GitRepository:
+    """Access to to metadata about the Git repository of the documentation
+    project.
+    """
+
+    def __init__(self, dirname: Path) -> None:
+        self._repo = Repo(dirname, search_parent_directories=True)
+
+    @property
+    def working_tree_dir(self) -> Path:
+        """The root directory of the Git repository."""
+        path = self._repo.working_tree_dir
+        if path is None:
+            raise RuntimeError("Git repository is not available.")
+        return Path(path)

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -210,7 +210,7 @@ html_context: Dict[str, Any] = {}
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "header_links_before_dropdown": 5,
+    "header_links_before_dropdown": _conf.header_links_before_dropdown,
     "external_links": [{"name": "Rubin docs", "url": "https://www.lsst.io"}],
     "icon_links": [],
     "logo": {

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -6,7 +6,7 @@ containing::
     from documenteer.conf.guide import *
 """
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 from documenteer.conf import (
     DocumenteerConfig,
@@ -237,10 +237,11 @@ if _conf.github_url:
         }
     )
 
-# in pydata-sphinx-theme 0.10.0 it'll be possible to use
-# :html_theme.sidebar_secondary.remove: metadata to remove the sidebar
-# for a specific page instead
-html_sidebars: Dict[str, List[Any]] = {"index": [], "changelog": []}
+# Specifies templates to put in the primary (left) sidebars of
+# specific pages (by their docname or pattern). An empty list results in the
+# sidebar being dropped altogether.
+html_sidebars: Dict[str, List[str]] = {"index": [], "changelog": []}
+_conf.disable_primary_sidebars(html_sidebars)
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -6,7 +6,7 @@ containing::
     from documenteer.conf.guide import *
 """
 
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from documenteer.conf import (
     DocumenteerConfig,
@@ -62,6 +62,7 @@ __all__ = [
     "linkcheck_timeout",
     # HTML
     "html_theme",
+    "html_context",
     "html_theme_options",
     "html_sidebars",
     "html_title",
@@ -202,6 +203,9 @@ linkcheck_timeout = 15
 
 html_theme = "pydata_sphinx_theme"
 
+# Context available to Jinja templates
+html_context: Dict[str, Any] = {}
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -236,6 +240,9 @@ if _conf.github_url:
             "type": "fontawesome",
         }
     )
+
+# Configure the "Edit this page" link
+_conf.set_edit_on_github(html_theme_options, html_context)
 
 # Specifies templates to put in the primary (left) sidebars of
 # specific pages (by their docname or pattern). An empty list results in the

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -101,6 +101,7 @@ _conf = DocumenteerConfig.find_and_load()
 
 extensions = [
     "myst_parser",
+    "sphinx_copybutton",
     "sphinx_design",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -276,7 +276,7 @@ html_show_sourcelink = False
 
 # Automodapi
 # https://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html
-automodapi_toctreedirnm = "api"
+automodapi_toctreedirnm = _conf.automodapi_toctreedirm
 
 # sphinx_autodoc_typehints
 always_document_param_types = True

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import pytest
 from sphinx.errors import ConfigError
@@ -60,6 +60,22 @@ copyright = "2022 AURA"
 
 [project.python]
 package = "documenteer"
+"""
+
+EXAMPLE_SIDEBARS = """
+
+[project]
+title = "Documenteer"
+copyright = "2022 AURA"
+
+[project.python]
+package = "documenteer"
+
+[sphinx]
+disable_primary_sidebars = [
+    "index",
+    "changelog",
+]
 """
 
 
@@ -131,3 +147,19 @@ def test_append_linkcheck_ignore() -> None:
         r"^https://ls.st/",
         r"^https://confluence.lsstcorp.org/",
     ]
+
+
+def test_disable_primary_sidebars_defaults() -> None:
+    """Test sphinx.disable_primary_sidebars defaults where it wasn't set."""
+    config = DocumenteerConfig.load(EXAMPLE)
+    html_sidebars: Dict[str, List[str]] = {}
+    config.disable_primary_sidebars(html_sidebars)
+    assert html_sidebars == {"index": []}
+
+
+def test_disable_primary_sidebars() -> None:
+    """Test sphinx.disable_primary_sidebars."""
+    config = DocumenteerConfig.load(EXAMPLE_SIDEBARS)
+    html_sidebars: Dict[str, List[str]] = {}
+    config.disable_primary_sidebars(html_sidebars)
+    assert html_sidebars == {"index": [], "changelog": []}

--- a/tests/test_conf_toml.py
+++ b/tests/test_conf_toml.py
@@ -86,6 +86,7 @@ def test_load() -> None:
     assert config.copyright == "2022 AURA"
     assert config.github_url == "https://github.com/lsst-sqre/documenteer"
     assert config.version == "1.0.0"
+    assert config.automodapi_toctreedirm == "api"
 
 
 def test_bad_package() -> None:


### PR DESCRIPTION
More features for Rubin user guides:

- Code cells now include a copy button
- Pages now feature a link to edit the source on GitHub (the github repo can be automatically detected from pyproject.toml metadata and the path of the docs directory relative to the repository root is discovered with GitPython).
- More configurations available through documenteer.toml, rather than conf.py
  - disabling primary side bars on certain pages
  - setting the Python API content directory for autoodapi
  - setting the number header links to show in the nav bar