### PR TITLE
DM-36351: Add support for sphinxext.opengraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ guide = [
     "myst-parser",
     "markdown-it-py[linkify]",
     "sphinxcontrib-mermaid",
+    "sphinxext-opengraph",
 ]
 technote = [
     # Theme and extensions for technotes

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -32,6 +32,8 @@ from documenteer.conf import (
 #     MyST markdown configurations
 # #MERMIAID
 #     Mermaid diagram support
+# #OPENGRAPH
+#     OpenGraph metadata support
 
 
 # Ordered as they are declared in this module
@@ -95,6 +97,10 @@ __all__ = [
     "myst_enable_extensions",
     # MERMAID
     "mermaid_output_format",
+    # OPENGRAPH
+    "ogp_site_url",
+    "ogp_site_name",
+    "ogp_use_first_image",
 ]
 
 _conf = DocumenteerConfig.find_and_load()
@@ -109,6 +115,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinxcontrib.mermaid",
+    "sphinxext.opengraph",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
@@ -340,3 +347,13 @@ myst_enable_extensions = [
 # The raw format renders the diagram client-side, and doesn't require a
 # Mermaid CLI installation
 mermaid_output_format = "raw"
+
+# ============================================================================
+# #OPENGRAPH OpenGraph diagram support
+# https://github.com/wpilibsuite/sphinxext-opengraph
+# https://ogp.me/
+# ============================================================================
+
+ogp_site_url = _conf.base_url
+ogp_site_name = _conf.project
+ogp_use_first_image = True


### PR DESCRIPTION
This comes via the sphinxext.opengraph extension published at https://github.com/wpilibsuite/sphinxext-opengraph. The basic configuration for the extension reuses already existing metadata compiled through the basic project configuration.

Supporting custom opengraph images will require more work, however there's a hint in https://github.com/wpilibsuite/sphinxext-opengraph/issues/66 that autogenerated preview images are in the works, so let's see how that plays out. 🎉 