### PR TITLE
DM-36665: Drop version from homepage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,8 @@ Documenteer
 
 **Sphinx extensions, configurations, and tooling for Rubin Observatory documentation projects.**
 
-This documentation is for version |version|. `Find docs for other versions. <https://documenteer.lsst.io/v>`__
 Documenteer is developed on GitHub at https://github.com/lsst-sqre/documenteer.
+Find other version of the documentation at https://documenteer.lsst.io/v
 
 .. _pip-install:
 .. _installation:


### PR DESCRIPTION
Because of how setuptools_scm work, this will never be the release tag when tracking main, so this change is to reduce confusion from long version strings.