### PR TITLE
DM-37481: Fix emergent GitHub Actions issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: check-toml
@@ -14,14 +14,14 @@ repos:
         files: (README\.rst)|(CHANGELOG\.rst)
 
   - repo: https://github.com/PyCQA/isort/
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
 
@@ -29,10 +29,10 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==20.8b1]
+        additional_dependencies: [black==22.12.0]
         args: [-l, '79', -t, py38]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 init:
 	rm -rf .tox
 	pip install -e ".[dev,guide,technote,pipelines]"
-	pip install tox tox-pyenv pre-commit
+	pip install tox pre-commit
 	pre-commit install
 
 .PHONY: clean

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -226,7 +226,7 @@ class DocumenteerConfig:
     @classmethod
     def find_and_load(cls) -> DocumenteerConfig:
         path = Path("documenteer.toml")
-        if not path.is_file:
+        if not path.is_file():
             raise ConfigError("Cannot find the documenteer.toml file.")
         return cls.load(path.read_text())
 


### PR DESCRIPTION
- drop tox-pyenv since tox-pyenv doesn't appear to worth with tox version 4.
- Fixed small typo that caused a typing issue
- Refreshed pre-commit hooks