### PR TITLE
Update pre-commit plugins

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -18,6 +18,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         sphinx-version:
           - "5"
           - "dev"
@@ -60,7 +61,7 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-lint"
           use-cache: false
 
@@ -91,5 +92,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ""
-          python-version: "3.10"
+          python-version: "3.11"
           upload: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -38,6 +38,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
         sphinx-version:
           - '5'
 
@@ -82,7 +83,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           tox-envs: 'docs,docs-lint'
 
       # Only attempt documentation uploads for tagged releases and pull
@@ -123,5 +124,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
-          python-version: '3.10'
+          python-version: '3.11'
           upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Python environments
+.venv
+venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,19 +14,19 @@ repos:
         files: (README\.rst)|(CHANGELOG\.rst)
 
   - repo: https://github.com/PyCQA/isort/
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.12.0]
@@ -38,7 +38,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.7.1'
+    rev: 'v3.0.0-alpha.4'
     hooks:
       - id: prettier
         types_or: [css, scss, javascript]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",

--- a/src/documenteer/sphinxext/lssttasks/topiclists.py
+++ b/src/documenteer/sphinxext/lssttasks/topiclists.py
@@ -161,7 +161,6 @@ class PipelineTaskListDirective(BaseTopicListDirective):
 
 
 class ConfigurableListDirective(BaseTopicListDirective):
-
     directive_name = "lsst-configurables"
 
     @property
@@ -170,7 +169,6 @@ class ConfigurableListDirective(BaseTopicListDirective):
 
 
 class ConfigListDirective(TaskListDirective):
-
     directive_name = "lsst-configs"
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py{37,38,39}-test-sphinx{5}
+    py-test-sphinx{5}
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
- Update pre-commit plugins and apply a black formatting fix
- Don't require all Python versions to have run for collecting coverage results in tox