### PR TITLE
DM-38168: Pin pydata-sphinx-theme < 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   These technotes are now themed with Rubin's modern branding.
 - Drop support for Python 3.7.
 - Drop support for Sphinx versions earlier than 5.
+- Temporarily pin pydata-sphinx-theme < 0.13 on account of a change in logo path checking (affects user guide projects).
 
 ## 0.7.0 (2022-10-20)
 

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -33,7 +33,7 @@ base\_url
 
 |optional| |py-auto|
 
-The root URL of the documentation project, used to set the `canonical URL link rel <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-canonical>`__, which is valuable for search engines.
+The root URL of the documentation project, used to set the `canonical URL link rel <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel>`__, which is valuable for search engines.
 
 .. code-block:: toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 guide = [
     # Theme and extensions for Rubin user guide projects
     "sphinx_design",
-    "pydata-sphinx-theme>=0.10.0",
+    "pydata-sphinx-theme>=0.10.0,<0.13.0",
     "sphinx-autodoc-typehints",
     "sphinx-automodapi",
     "sphinx-copybutton",


### PR DESCRIPTION
The extra path checking involved in the light and dark logos in the
html_theme_options isn't compatible with images installed via
html_static_path.