### PR TITLE
DM-38388: Improve source exclusions for user guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Drop support for Python 3.7.
 - Drop support for Sphinx versions earlier than 5.
 - Temporarily pin pydata-sphinx-theme < 0.13 on account of a change in logo path checking (affects user guide projects).
+- Add a new `sphinx.exclude` field to `documenteer.toml` to list files for exclusion from a documentation project.
+  More files and directories like `.venv` and `requirements.txt` are now excluded, as well.
 
 ## 0.7.0 (2022-10-20)
 

--- a/docs/guides/toml-reference.rst
+++ b/docs/guides/toml-reference.rst
@@ -165,6 +165,15 @@ The default is ``["index"]`` to remove the sidebar from the homepage.
    This configuration is for the **primary** sidebar, on the left side, containing side or section-level navigation links.
    To remove the page-level contents sidebar, on the right side, add ``:html_theme.sidebar_secondary.remove:`` to the *page's* file metadata.
 
+exclude
+-------
+
+|optional|
+
+A list of file paths, relative to :file:`conf.py`, to exclude from the Sphinx build.
+This configuration is often used to prevent file unrelated to the documentation from being accidentally included in the site build.
+|documenteer.conf.guide| includes common files and directories, so you may not need to modify this configuration in standard situations.
+
 extensions
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,3 +167,4 @@ strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+plugins = ["pydantic.mypy"]

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -202,6 +202,14 @@ class SphinxModel(BaseModel):
         ),
     )
 
+    exclude: List[str] = Field(
+        description=(
+            "List of paths to exclude from being considered as Sphinx content "
+            "sources."
+        ),
+        default_factory=list,
+    )
+
     theme: ThemeModel = Field(default_factory=lambda: ThemeModel())
 
     intersphinx: Optional[IntersphinxModel]
@@ -405,6 +413,13 @@ class DocumenteerConfig:
             return self.conf.sphinx.nitpicky
         else:
             return False
+
+    def extend_exclude_patterns(self, exclude_patterns: List[str]) -> None:
+        """Extend Sphinx ``exclude_patterns`` with the "exclude" configuration
+        from the sphinx TOML table.
+        """
+        if self.conf.sphinx and self.conf.sphinx.exclude:
+            exclude_patterns.extend(self.conf.sphinx.exclude)
 
     def disable_primary_sidebars(
         self, html_sidebars: MutableMapping[str, List[str]]

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -156,7 +156,16 @@ language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "README.rst", "README.md"]
+exclude_patterns = [
+    "_build",
+    "README.rst",
+    "README.md",
+    ".venv",
+    "venv",
+    "requirements.txt",
+    ".github",
+    ".tox",
+]
 
 if _conf.rst_epilog_path:
     exclude_patterns.append(str(_conf.rst_epilog_path))

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -166,6 +166,7 @@ exclude_patterns = [
     ".github",
     ".tox",
 ]
+_conf.extend_exclude_patterns(exclude_patterns)
 
 if _conf.rst_epilog_path:
     exclude_patterns.append(str(_conf.rst_epilog_path))


### PR DESCRIPTION
- Add a `sphinx.exclude` field for documenteer.toml to set what files/directories to exclude from the Sphinx build. This config appends to the Sphinx `exclude_patterns` variable.
- Add `requirements.txt` and `.venv`/`venv` to the default `exclude_patterns`.