### PR TITLE
Pin Sphinx < 7 for pipelines, technote

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -18,9 +18,11 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         sphinx-version:
           - "4"
           - "5"
+          - "6"
           - "dev"
 
     steps:
@@ -46,7 +48,7 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-lint"
           use-cache: false
 
@@ -62,5 +64,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ""
-          python-version: "3.10"
+          python-version: "3.11"
           upload: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -40,11 +40,16 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         sphinx-version:
           - "2"
           - "3"
           - "4"
           - "5"
+          - "6"
+        exclude:
+          - python-version: "3.7"
+            sphinx-version: "6"
 
     steps:
       - uses: actions/checkout@v3
@@ -71,7 +76,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-lint"
 
       # Only attempt documentation uploads for tagged releases and pull
@@ -103,5 +108,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
-          python-version: "3.10"
+          python-version: "3.11"
           upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.7.4 (2023-05-16)
+
+Fixes:
+
+- Pinned Sphinx < 7 for the `pipelines` and `technote` extras since their themes are not currently compatible with Sphinx 7 and later.
+
 ## 0.7.3 (2023-03-20)
 
 Fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,13 @@ guide = [
 ]
 technote = [
     # Theme and extensions for technotes
+    "sphinx<7.0.0",
     "lsst-dd-rtd-theme>=0.2.3,<0.3.0",
     "sphinx-prompt",
 ]
 pipelines = [
     # Theme and extensions for pipelines.lsst.io
+    "sphinx<7.0.0",
     "lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0",
     "numpydoc",
     "sphinx-automodapi",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py-test-sphinx5
+    py-test-sphinx6
     coverage-report
-    typing-sphinx5
+    typing-sphinx6
     lint
     docs
     docs-lint
@@ -16,12 +16,15 @@ description =
     sphinx2: with sphinx 2.*
     sphinx3: with sphinx 3.*
     sphinx4: with sphinx 4.*
+    sphinx5: with sphinx 5.*
+    sphinx6: with sphinx 6.*
     sphinxdev: with sphinx master branch
 deps =
     sphinx2: sphinx==2.*
     sphinx3: sphinx==3.*
     sphinx4: sphinx==4.*
     sphinx5: sphinx==5.*
+    sphinx6: sphinx==6.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx
 extras =
     dev
@@ -36,7 +39,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py{37,38,39}-test-sphinx{2,3,4,5}
+    py-test-sphinx{2,3,4,5,6}
 commands =
     coverage combine
     coverage report
@@ -56,6 +59,7 @@ deps =
     sphinx3: sphinx==3.*
     sphinx4: sphinx==4.*
     sphinx5: sphinx==5.*
+    sphinx6: sphinx==6.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx
 commands =
     mypy src tests


### PR DESCRIPTION
Pinned Sphinx < 7 for the `pipelines` and `technote` extras since their themes are not currently compatible with Sphinx 7 and later.