### PR TITLE
DM-39580: Add sphinxcontrib-jquery (0.7 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.7.5 (2023-06-07)
+
+Fixes:
+
+- Use [sphinxcontrib-jquery](https://github.com/sphinx-contrib/jquery/) to ensure jQuery is available for user guide and Pipelines documentation builds. Sphinx 6 dropped jQuery from its default theme, and the new pydata-sphinx-theme v0.12 does not include it either.
+
 ## 0.7.4 (2023-05-16)
 
 Fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ guide = [
     "markdown-it-py[linkify]",
     "sphinxcontrib-mermaid",
     "sphinxext-opengraph",
+    "sphinxcontrib-jquery",
 ]
 technote = [
     # Theme and extensions for technotes
@@ -90,6 +91,7 @@ pipelines = [
     "sphinx-prompt",
     "sphinxcontrib-doxylink",
     "sphinx-click",
+    "sphinxcontrib-jquery",
 ]
 
 [project.urls]

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -112,6 +112,7 @@ _conf = DocumenteerConfig.find_and_load()
 # ============================================================================
 
 extensions = [
+    "sphinxcontrib.jquery",
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",

--- a/src/documenteer/conf/pipelines.py
+++ b/src/documenteer/conf/pipelines.py
@@ -118,6 +118,7 @@ except Exception as e:
     print(f"Error getting sphinx-jinja version: {str(e)}")
 
 extensions = [
+    "sphinxcontrib.jquery",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
Sphinx 6 stopped including jquery by default, but the pydata-sphinx-theme 0.12 release we're using doesn't include it. The temporary stop gap is to use sphinxcontrib-jquery.

https://github.com/sphinx-contrib/jquery/