### PR TITLE
DM-39580: Add sphinxcontrib-jquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Drop support for Python 3.7.
 - Drop support for Sphinx versions earlier than 5.
 - Temporarily pin pydata-sphinx-theme < 0.13 on account of a change in logo path checking (affects user guide projects).
+- Use [sphinxcontrib-jquery](https://github.com/sphinx-contrib/jquery/) to ensure jQuery is available for user guide and Pipelines documentation builds.
 - Add a new `sphinx.exclude` field to `documenteer.toml` to list files for exclusion from a documentation project.
   More files and directories like `.venv` and `requirements.txt` are now excluded, as well.
 - New support for embedding OpenAPI documentation in a Redoc-generated subsite. The `documenteer.ext.openapi` extension can call a user-specified function to generate and install the OpenAPI specification the Sphinx source. For user guide projects, the `[project.openapi]` table in `documenteer.toml` can be used to configure both the `documenteer.ext.openapi` and `sphinxcontrib-redoc` extensions. [sphinxcontrib-redoc](https://sphinxcontrib-redoc.readthedocs.io/en/stable/) is installed and configured by default for all Rubin user guide projects (projects that use `documenteer.conf.guide`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ guide = [
     "sphinxcontrib-mermaid",
     "sphinxext-opengraph",
     "sphinxcontrib-redoc",
+    "sphinxcontrib-jquery",
 ]
 technote = [
     # Theme and extensions for technotes
@@ -87,6 +88,7 @@ pipelines = [
     "sphinx-prompt",
     "sphinxcontrib-doxylink",
     "sphinx-click",
+    "sphinxcontrib-jquery",
 ]
 
 [project.urls]

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -119,6 +119,7 @@ _conf = DocumenteerConfig.find_and_load()
 # ============================================================================
 
 extensions = [
+    "sphinxcontrib.jquery",
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",

--- a/src/documenteer/conf/pipelines.py
+++ b/src/documenteer/conf/pipelines.py
@@ -118,6 +118,7 @@ except Exception as e:
     print(f"Error getting sphinx-jinja version: {str(e)}")
 
 extensions = [
+    "sphinxcontrib.jquery",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
Use [sphinxcontrib-jquery](https://github.com/sphinx-contrib/jquery/) to ensure jQuery is available for user guide and Pipelines documentation builds.

Sphinx 6 stopped including jquery by default. Once we update to pydata-sphinx-theme 0.13 we can drop this extension.

Merge after #159 