### PR TITLE
DM-39580: Document import of get_openapi

### DIFF
--- a/docs/guides/openapi.rst
+++ b/docs/guides/openapi.rst
@@ -21,6 +21,7 @@ For SQuaRE/Safir-standardized FastAPI applications, it may make sense to add thi
    import json
 
    from fastapi import FastAPI
+   from fastapi.openapi.utils import get_openapi
 
 
    app = FastAPI()

--- a/docs/sphinx-extensions/openapi.rst
+++ b/docs/sphinx-extensions/openapi.rst
@@ -30,6 +30,7 @@ For FastAPI applications, it may make sense to add this function to the :file:`m
    import json
 
    from fastapi import FastAPI
+   from fastapi.openapi.utils import get_openapi
 
 
    app = FastAPI()


### PR DESCRIPTION
Fix documentation examples for the documenteer.ext.openapi extension.