### PR TITLE
DM-37783: Add -W flag to package-docs build / stack-docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.venv/
+demo/
+node_modules/
+src/documenteer/assets/rsd-assets/
+src/documenteer/assets/scripts/
+src/documenteer/assets/styles/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,15 @@ repos:
           - toml
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.13.0
+    rev: 1.14.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.1.0]
+        additional_dependencies: [black==23.3.0]
         args: [-l, '79', -t, py38]
 
   - repo: https://github.com/pycqa/flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.8.0 (2023-07-21)
+
+New features:
+
+- Added a `-W` / `--warning-is-error` flag to the `package-docs build` and `stack-docs build` commands for Science Pipelines documentation builds. This flag causes Sphinx to treat warnings as errors, which is useful for CI builds.
+
 ## 0.7.5 (2023-06-07)
 
 Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
-## 0.8.0 (2023-07-21)
+## 0.8.0 (2023-07-23)
 
 New features:
 
 - Added a `-W` / `--warning-is-error` flag to the `package-docs build` and `stack-docs build` commands for Science Pipelines documentation builds. This flag causes Sphinx to treat warnings as errors, which is useful for CI builds.
+
+Fixes:
+
+- Pinned `sphinx-autodoc-typehints<1.23.0` to avoid a Sphinx version conflict with `sphinx-design`. The former required Sphinx >= 7.
 
 ## 0.7.5 (2023-06-07)
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 init:
 	rm -rf .tox
 	pip install -e ".[dev,guide,technote,pipelines]"
-	pip install tox tox-pyenv pre-commit
+	pip install tox pre-commit
 	pre-commit install
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation](https://img.shields.io/badge/documenteer-lsst.io-brightgreen.svg)](https://documentation.lsst.io)
+[![Documentation](https://img.shields.io/badge/documenteer-lsst.io-brightgreen.svg)](https://documenteer.lsst.io)
 [![PyPI](https://img.shields.io/pypi/v/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
 [![For Python 3.7+](https://img.shields.io/pypi/pyversions/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
 [![MIT license](https://img.shields.io/pypi/l/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
@@ -18,7 +18,7 @@ Browse the [lsst-doc-engineering](https://github.com/topics/lsst-doc-engineering
 For [user guides](https://documenteer.lsst.io/guides/index.html):
 
 ```sh
-pip install "documenteer[technote]"
+pip install "documenteer[guides]"
 ```
 
 For [technical note projects](https://documenteer.lsst.io/technotes/index.html):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ guide = [
     # Theme and extensions for Rubin user guide projects
     "sphinx_design",
     "pydata-sphinx-theme>=0.10.0,<0.13.0",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints<1.23.0",  # avoid requiring Sphinx > 7 only
     "sphinx-automodapi",
     "sphinx-copybutton",
     "sphinx-prompt",

--- a/src/documenteer/sphinxrunner.py
+++ b/src/documenteer/sphinxrunner.py
@@ -15,6 +15,7 @@ def run_sphinx(
     root_dir: Union[str, Path],
     job_count: int = 1,
     warnings_as_errors: bool = False,
+    nitpicky: bool = False,
 ) -> int:
     """Run the Sphinx build process.
 
@@ -28,6 +29,8 @@ def run_sphinx(
         Number of cores to run the Sphinx build with (``-j`` flag)
     warnings_as_errors : `bool`
         If ``True``, treat Sphinx warnings as errors (``-W`` flag).
+    nitpicky : `bool`
+        If ``True``, activate Sphinx's nitpicky mode (``-n`` flag).
 
     Returns
     -------
@@ -53,6 +56,8 @@ def run_sphinx(
     ]
     if warnings_as_errors:
         argv.append("-W")
+    if nitpicky:
+        argv.append("-n")
     argv.extend([src_dir, os.path.join("_build", "html")])
 
     start_dir = os.path.abspath(".")

--- a/src/documenteer/sphinxrunner.py
+++ b/src/documenteer/sphinxrunner.py
@@ -26,6 +26,8 @@ def run_sphinx(
         configuration file.
     job_count : `int`
         Number of cores to run the Sphinx build with (``-j`` flag)
+    warnings_as_errors : `bool`
+        If ``True``, treat Sphinx warnings as errors (``-W`` flag).
 
     Returns
     -------

--- a/src/documenteer/stackdocs/build.py
+++ b/src/documenteer/stackdocs/build.py
@@ -39,6 +39,7 @@ def build_stack_docs(
     select_doxygen_packages: Optional[List[str]] = None,
     skip_doxygen_packages: Optional[List[str]] = None,
     warning_is_error: bool = False,
+    nitpicky: bool = False,
 ) -> int:
     """Build stack Sphinx documentation (main entrypoint).
 
@@ -80,6 +81,9 @@ def build_stack_docs(
         set of packages processed by Doxygen.
     warning_is_error
         If ``True``, warnings from Sphinx will be treated as errors.
+    nitpicky
+        If ``True``, run Sphinx in "nitpicky" mode that generates warnings
+        for more things like unresolved links.
 
     Returns
     -------
@@ -240,7 +244,9 @@ def build_stack_docs(
     # Trigger the Sphinx build
     if enable_sphinx:
         return run_sphinx(
-            root_project_dir, warnings_as_errors=warning_is_error
+            root_project_dir,
+            warnings_as_errors=warning_is_error,
+            nitpicky=nitpicky,
         )
     else:
         return 0

--- a/src/documenteer/stackdocs/build.py
+++ b/src/documenteer/stackdocs/build.py
@@ -38,6 +38,7 @@ def build_stack_docs(
     enable_sphinx: bool = True,
     select_doxygen_packages: Optional[List[str]] = None,
     skip_doxygen_packages: Optional[List[str]] = None,
+    warning_is_error: bool = False,
 ) -> int:
     """Build stack Sphinx documentation (main entrypoint).
 
@@ -77,6 +78,8 @@ def build_stack_docs(
     skip_doxygen_packages
         If set, EUPS packages named in this sequence will be removed from the
         set of packages processed by Doxygen.
+    warning_is_error
+        If ``True``, warnings from Sphinx will be treated as errors.
 
     Returns
     -------
@@ -236,7 +239,9 @@ def build_stack_docs(
 
     # Trigger the Sphinx build
     if enable_sphinx:
-        return run_sphinx(root_project_dir)
+        return run_sphinx(
+            root_project_dir, warnings_as_errors=warning_is_error
+        )
     else:
         return 0
 

--- a/src/documenteer/stackdocs/packagecli.py
+++ b/src/documenteer/stackdocs/packagecli.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import sys
+from typing import Any
 
 import click
 
@@ -94,14 +95,19 @@ def help(ctx, topic, **kw):
 
 
 @main.command()
+@click.option(
+    "-W", "--warning-is-error", is_flag=True, help="Treat warnings as errors."
+)
 @click.pass_context
-def build(ctx):
+def build(ctx: Any, warning_is_error: bool) -> None:
     """Build documentation as HTML.
 
     The build HTML site is located in the ``doc/_build/html`` directory
     of the package.
     """
-    return_code = run_sphinx(ctx.obj["root_dir"])
+    return_code = run_sphinx(
+        ctx.obj["root_dir"], warnings_as_errors=warning_is_error
+    )
     if return_code > 0:
         sys.exit(return_code)
 

--- a/src/documenteer/stackdocs/packagecli.py
+++ b/src/documenteer/stackdocs/packagecli.py
@@ -98,15 +98,20 @@ def help(ctx, topic, **kw):
 @click.option(
     "-W", "--warning-is-error", is_flag=True, help="Treat warnings as errors."
 )
+@click.option(
+    "-n", "--nitpicky", is_flag=True, help="Activate Sphinx's nitpicky mode."
+)
 @click.pass_context
-def build(ctx: Any, warning_is_error: bool) -> None:
+def build(ctx: Any, warning_is_error: bool, nitpicky: bool) -> None:
     """Build documentation as HTML.
 
     The build HTML site is located in the ``doc/_build/html`` directory
     of the package.
     """
     return_code = run_sphinx(
-        ctx.obj["root_dir"], warnings_as_errors=warning_is_error
+        ctx.obj["root_dir"],
+        warnings_as_errors=warning_is_error,
+        nitpicky=nitpicky,
     )
     if return_code > 0:
         sys.exit(return_code)

--- a/src/documenteer/stackdocs/stackcli.py
+++ b/src/documenteer/stackdocs/stackcli.py
@@ -162,6 +162,9 @@ def help(ctx, topic, **kw):
     multiple=True,
     help=("Skip running Doxygen on these packages."),
 )
+@click.option(
+    "-W", "--warning-is-error", is_flag=True, help="Treat warnings as errors."
+)
 @click.pass_context
 def build(
     ctx,
@@ -174,6 +177,7 @@ def build(
     doxygen_conf_defaults_path,
     dox,
     skip_dox,
+    warning_is_error,
 ):
     """Build documentation as HTML.
 
@@ -213,6 +217,7 @@ def build(
         enable_sphinx=enable_sphinx,
         select_doxygen_packages=dox,
         skip_doxygen_packages=skip_dox,
+        warning_is_error=warning_is_error,
     )
     if return_code > 0:
         sys.exit(return_code)

--- a/src/documenteer/stackdocs/stackcli.py
+++ b/src/documenteer/stackdocs/stackcli.py
@@ -165,6 +165,9 @@ def help(ctx, topic, **kw):
 @click.option(
     "-W", "--warning-is-error", is_flag=True, help="Treat warnings as errors."
 )
+@click.option(
+    "-n", "--nitpicky", is_flag=True, help="Activate Sphinx's nitpicky mode."
+)
 @click.pass_context
 def build(
     ctx,
@@ -178,6 +181,7 @@ def build(
     dox,
     skip_dox,
     warning_is_error,
+    nitpicky,
 ):
     """Build documentation as HTML.
 
@@ -218,6 +222,7 @@ def build(
         select_doxygen_packages=dox,
         skip_doxygen_packages=skip_dox,
         warning_is_error=warning_is_error,
+        nitpicky=nitpicky,
     )
     if return_code > 0:
         sys.exit(return_code)


### PR DESCRIPTION
Adds a `-W` / `--warning-is-error` flag to the `package-docs build` and `stack-docs build` commands for Science Pipelines documentation builds. This flag causes Sphinx to treat warnings as errors, which is useful for CI builds.

Will be released as 0.8.0