### PR TITLE
Fix typos on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation](https://img.shields.io/badge/documenteer-lsst.io-brightgreen.svg)](https://documentation.lsst.io)
+[![Documentation](https://img.shields.io/badge/documenteer-lsst.io-brightgreen.svg)](https://documenteer.lsst.io)
 [![PyPI](https://img.shields.io/pypi/v/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
 [![For Python 3.7+](https://img.shields.io/pypi/pyversions/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
 [![MIT license](https://img.shields.io/pypi/l/documenteer.svg?style=flat-square)](https://pypi.python.org/pypi/documenteer)
@@ -18,7 +18,7 @@ Browse the [lsst-doc-engineering](https://github.com/topics/lsst-doc-engineering
 For [user guides](https://documenteer.lsst.io/guides/index.html):
 
 ```sh
-pip install "documenteer[technote]"
+pip install "documenteer[guide]"
 ```
 
 For [technical note projects](https://documenteer.lsst.io/technotes/index.html):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ guide = [
     # Theme and extensions for Rubin user guide projects
     "sphinx_design",
     "pydata-sphinx-theme>=0.10.0,<0.13.0",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints<1.23.0",  # avoid requiring Sphinx > 7 only
     "sphinx-automodapi",
     "sphinx-copybutton",
     "sphinx-prompt",


### PR DESCRIPTION
This also sneaks in a hot-fix constraint on sphinx-autodoc-typehints<1.23.0 to avoid a Sphinx version constraint conflict between sphinx-design (<7 currently) and sphinx-autodoc-typehints.