### PR TITLE
DM-39884: Pin Pydantic < 2 (0.8.3 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.8.3 (2023-07-03)
+
+Fixes:
+
+- Pin Pydantic < 2.0.0. This is a temporary measure while we add and test compatibility with Pydantic 1 and 2.
+
 ## 0.8.2 (2023-06-27)
 
 Fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "sphinxcontrib-bibtex>=2.0.0",  # for pybtex plugin; bibtex_bibfiles config is required.
     "importlib_metadata; python_version < \"3.8\"",
     "tomli; python_version < \"3.11\"",
-    "pydantic",
+    "pydantic<2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pin Pydantic < 2. This is meant as a temporary measure to get a stable
PyPI release for guide and technote users while we put out a release
that is compatible with both Pydantic v1 and v2.