### PR TITLE
DM-39884: Pin pydantic < 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a new `sphinx.exclude` field to `documenteer.toml` to list files for exclusion from a documentation project.
   More files and directories like `.venv` and `requirements.txt` are now excluded, as well.
 - New support for embedding OpenAPI documentation in a Redoc-generated subsite. The `documenteer.ext.openapi` extension can call a user-specified function to generate and install the OpenAPI specification the Sphinx source. For user guide projects, the `[project.openapi]` table in `documenteer.toml` can be used to configure both the `documenteer.ext.openapi` and `sphinxcontrib-redoc` extensions. [sphinxcontrib-redoc](https://sphinxcontrib-redoc.readthedocs.io/en/stable/) is installed and configured by default for all Rubin user guide projects (projects that use `documenteer.conf.guide`).
+- Pin pydantic < 2.0.
 
 ## 0.8.1 (2023-06-27)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "sphinxcontrib-bibtex>=2.0.0",                  # for pybtex plugin; bibtex_bibfiles config is required.
     "importlib_metadata; python_version < \"3.8\"",
     "tomli; python_version < \"3.11\"",
-    "pydantic",
+    "pydantic < 2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pins pydantic < 2 for the main line development branch.