### PR TITLE
DM-39837: Check package version in GitHub Action release published event

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,12 @@ jobs:
           npm install
           npm run build
 
+      - name: Show package version
+        run: |
+          python -c 'import documenteer; print(documenteer.__version__)'
+
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@tickets/DM-39837
         with:
           python-version: '3.11'
+          upload: 'false'


### PR DESCRIPTION
This is to double check that a release published-based workflow is getting the right package version. We'll revert this change to re-enable PyPI uploads when we're confident.