### PR TITLE
DM-39837: Do version check in tox.ini

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,10 +141,6 @@ jobs:
           npm install
           npm run build
 
-      - name: Show package version
-        run: |
-          python -c 'import documenteer; print(documenteer.__version__)'
-
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@tickets/DM-39837
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ extras =
     technote
 commands=
     coverage run -m pytest {posargs}
+    python -c 'import documenteer; print(documenteer.__version__)'
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
The package isn't installed in the publish action job, of course.