### PR TITLE
DM-40228: Pin Sphinx < 7 for guides (0.8.4 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.8.4 (2023-07-28)
+
+Fixes:
+
+- Pin Sphinx < 7 for the `guide` extra (same as the pinning already being done for the `pipelines` and `technote` extras).
+
 ## 0.8.3 (2023-07-03)
 
 Fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dev = [
 ]
 guide = [
     # Theme and extensions for Rubin user guide projects
+    "sphinx<7.0.0",
     "sphinx_design",
     "pydata-sphinx-theme>=0.10.0,<0.13.0",
     "sphinx-autodoc-typehints<1.23.0",  # avoid requiring Sphinx > 7 only


### PR DESCRIPTION
We already make this pin for technotes and pipelines; we've seen reports now of an incompatibility with guides too.