### PR TITLE
DM-40815: Update to technote 0.3.0a2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ guide = [
 technote = [
     # Theme and extensions for technotes
     "sphinx<7",
-    "technote @ git+https://github.com/lsst-sqre/technote@main",
+    "technote>=0.3.0a2",
     "sphinx-prompt",
 ]
 pipelines = [


### PR DESCRIPTION
It's necessary to always use technote from PyPI in order to get the generated theme assets.