### PR TITLE
DM-41179: Update to technote 0.3.0a7

### DIFF
--- a/changelog.d/20231012_194757_jsick_DM_41179.md
+++ b/changelog.d/20231012_194757_jsick_DM_41179.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+-
+
+### Bug fixes
+
+- `Retry` is now imported directly from `urllib3` instead of the vendored version in requests.
+
+### Other changes
+
+- Updated to technote 0.3.0a7.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ guide = [
 technote = [
     # Theme and extensions for technotes
     "sphinx<7",
-    "technote==0.3.0a6",
+    "technote==0.3.0a7",
     "sphinx-prompt",
 ]
 pipelines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "click",
     "sphinxcontrib-bibtex>=2.0.0",                  # for pybtex plugin; bibtex_bibfiles config is required.
     "pydantic >= 2.0.0",
+    "urllib3",
 ]
 
 [project.optional-dependencies]

--- a/src/documenteer/requestsutils.py
+++ b/src/documenteer/requestsutils.py
@@ -5,7 +5,7 @@ __all__ = ("requests_retry_session",)
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util import Retry
 
 
 def requests_retry_session(

--- a/src/documenteer/templates/technote/sections/header-article.html
+++ b/src/documenteer/templates/technote/sections/header-article.html
@@ -2,13 +2,13 @@
   <ol class="rubin-technote-global-breadcrumbs">
     <li><a href="https://www.lsst.io/">Rubin Documentation</a></li>
     <li>
-      <a href="https://www.lsst.io/{{technote.toml.technote.series_id|lower}}/"
-        >{{technote.toml.technote.series_id}}</a
+      <a href="https://www.lsst.io/{{technote.metadata.series_id|lower}}/"
+        >{{technote.metadata.series_id}}</a
       >
     </li>
   </ol>
 
-  <p class="technote-article-header-id">{{technote.toml.technote.id}}</p>
+  <p class="technote-article-header-id">{{technote.metadata.id}}</p>
 
   <div class="rubin-technote-version-info">
     {% if technote.version %}


### PR DESCRIPTION
This version changed the jinja context variable so that the metadata is now accessed via a new metadata attribute, rather than from the "toml" representation.