### PR TITLE
DM-41214: Add a GitHub-based bibtex file cache extension

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -17,8 +17,7 @@ jobs:
         python-version:
           - "3.11"
         sphinx-version:
-          - "5"
-          - "6"
+          - "7"
           - "dev"
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,7 @@ jobs:
         python-version:
           - '3.11'
         sphinx-version:
-          - '5'
-          - '6'
+          - '7'
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ Fixes:
 
 - Documenteer works with the latest version of [sphinxcontrib-bibtex](https://github.com/mcmtroffaes/sphinxcontrib-bibtex).
   Both the new (`documenteer.conf.technote`) and old (`documenteer.sphinxconfig.technoteconf`) versions of the technote configuration use the new `bibtex_bibfiles` configuration variable.
-  Version 2.0.0 or later of `sphinxcontrib-bibtex`_ is now required because of that package's API.
+  Version 2.0.0 or later of `sphinxcontrib-bibtex` is now required because of that package's API.
 
 ## 0.6.2 (2020-10-08)
 

--- a/changelog.d/20231018_165310_jsick_DM_41214.md
+++ b/changelog.d/20231018_165310_jsick_DM_41214.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- Now requires Sphinx 7 and later (and docutils 0.20 and later)
+
+### New features
+
+- A new extension, `documenteer.ext.githubbibcache`, can fetch and locally cache bibtex files from one or more public GitHub repositories. These bibfiles are automatically added to `sphinxcontrib-bibtex`'s `bibtex_files` configuration.
+- Rubin technotes are now configured to automatically cache all bibfiles from the https://github.com/lsst/lsst-texmf repository. The `sphinxcontrib-bibtex` extension is available to technotes as well.

--- a/demo/rst-technote/.gitignore
+++ b/demo/rst-technote/.gitignore
@@ -1,1 +1,2 @@
 _build
+.technote

--- a/demo/rst-technote/index.rst
+++ b/demo/rst-technote/index.rst
@@ -16,6 +16,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin facilisis pharetr
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin facilisis pharetra neque, at semper nulla mattis auctor. Proin semper mollis enim eget interdum. Mauris eleifend eget diam vitae bibendum. Praesent ut aliquet odio, sodales imperdiet nisi. Nam interdum imperdiet tortor sed fringilla. Maecenas efficitur mi sodales nulla commodo rutrum. Ut ornare diam quam, sed commodo turpis aliquam et. In nec enim consequat, suscipit tortor sit amet, luctus ante. Integer dictum augue diam, non pulvinar massa euismod in. Morbi viverra condimentum auctor. Nullam et metus mauris. Cras risus ex, porta sit amet nibh et, dapibus auctor leo.
 
+A parenthetical citation :cite:p:`2017arXiv170309824V`. And a textual citation :cite:t:`2017arXiv170309824V`.
+
 Method
 ======
 
@@ -58,3 +60,8 @@ Conclusion
 ==========
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin facilisis pharetra neque, at semper nulla mattis auctor. Proin semper mollis enim eget interdum. Mauris eleifend eget diam vitae bibendum. Praesent ut aliquet odio, sodales imperdiet nisi. Nam interdum imperdiet tortor sed fringilla. Maecenas efficitur mi sodales nulla commodo rutrum. Ut ornare diam quam, sed commodo turpis aliquam et. In nec enim consequat, suscipit tortor sit amet, luctus ante. Integer dictum augue diam, non pulvinar massa euismod in. Morbi viverra condimentum auctor. Nullam et metus mauris. Cras risus ex, porta sit amet nibh et, dapibus auctor leo.
+
+References
+==========
+
+.. bibliography::

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -54,6 +54,7 @@
 .. _autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 .. _sphinx_autodoc_typehints: https://github.com/tox-dev/sphinx-autodoc-typehints
 .. _sphinxcontrib-redoc: https://sphinxcontrib-redoc.readthedocs.io/en/stable/
+.. _sphinxcontrib-bibtex: https://sphinxcontrib-bibtex.readthedocs.io/en/latest/
 .. _tox: https://tox.wiki/en/latest/
 .. _Technote: https://technote.lsst.io/
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -34,6 +34,7 @@ requests = "https://requests.readthedocs.io/en/latest/"
 developer = "https://developer.lsst.io/"
 pybtex = "https://docs.pybtex.org/"
 sphinx = "https://www.sphinx-doc.org/en/master/"
+sphinxcontrib-bibtex = "https://sphinxcontrib-bibtex.readthedocs.io/en/latest/"
 
 [sphinx.linkcheck]
 ignore = [

--- a/docs/sphinx-extensions/githubbibcache.rst
+++ b/docs/sphinx-extensions/githubbibcache.rst
@@ -1,0 +1,122 @@
+#################################
+Sourcing BibTeX files from GitHub
+#################################
+
+For documentation that references published documents, it's useful formally cite references in additional to the typical practice of linking directly to other webpages.
+In the Sphinx documentation system, a good workflow is to code bibliographic references through standard BibTeX files and then reference items in those BibTeX files with the sphinxcontrib-bibtex_ extension.
+At Rubin Observatory, we maintain a centralized set of BibTeX files in the https://github.com/lsst/lsst-texmf  repository.
+Documenteer provides a Sphinx extension, ``documenteer.ext.githubbibcache``, that downloads BibTeX files from one or more GitHub repositories, caches them, and automatically configures sphinxcontrib-bibtex_ to use those BibTeX files.
+This page explains how to set up ``documenteer.ext.githubbibcache`` in your Sphinx documentation project and use it in conjunction with the sphinxcontrib-bibtex_ extension.
+
+.. tip::
+
+   If you're using one of the Documenteer configuration presets for Rubin Observatory documents, your Sphinx project is already configured to use https://github.com/lsst/lsst-texmf bibliography files.
+   All you need to do is use the sphinxcontrib-bibtex_ extension's citation roles and ensure that a bibliography directive is present in your documentation project.
+
+Extension set up
+================
+
+The extension from Documenteer needs to be loaded _before_ the sphinxcontrib-bibtex_ extension because it adds configurations that are later used by sphinxcontrib-bibtex_.
+In your project's :file:`conf.py` file, set up the extensions like this:
+
+.. code-block:: python
+   :caption: conf.py
+
+   extensions = [
+       "documenteer.ext.githubbibcache",
+       "sphinxcontrib.bibtex",
+   ]
+
+.. note::
+
+   If you're using BibTeX files from https://github.com/lsst/lsst-texmf, you'll need to set also add an extension that supports Rubin Observatory's custom ``@DocuShare`` BibTeX entry type through :doc:`lsst-pybtex-style`.
+   This configuration is then:
+
+   .. code-block:: python
+      :caption: conf.py
+
+      extensions = [
+          "documenteer.sphinxext.bibtex",
+          "documenteer.ext.githubbibcache",
+          "sphinxcontrib.bibtex",
+      ]
+
+      bibtex_default_style = "lsst_aa"
+
+   The style configuration specifies the style provided by ``documenteer.sphinxext.bibtex``.
+
+Specify the GitHub repositories and their BibTeX files
+======================================================
+
+In :file:`conf.py`, you'll need to specify the GitHub repositories and their BibTeX files that you want to use.
+The ``documenteer_bibfile_github_repos`` variable is a list of dictionaries, where each dictionary has the following keys:
+
+- ``repo``: the GitHub repository name, e.g., ``lsst/lsst-texmf``.
+- ``ref``: the Git reference (branch, tag, or commit hash) to use, e.g., ``main``.
+- ``bibfiles``: a list of paths to BibTeX files to download from the repository, e.g., ``['texmf/bibtex/bib/refs.bib', 'texmf/bibtex/bib/lsst.bib']``.
+
+This is a sample configuration used in by Rubin Observatory's :doc:`technote configuration </technotes/index>`:
+
+.. code-block:: python
+   :caption: conf.py
+
+   documenteer_bibfile_cache_dir = ".technote/bibfiles"
+   documenteer_bibfile_github_repos = [
+       {
+           "repo": "lsst/lsst-texmf",
+           "ref": "main",
+           "bibfiles": [
+               "texmf/bibtex/bib/lsst.bib",
+               "texmf/bibtex/bib/lsst-dm.bib",
+               "texmf/bibtex/bib/refs_ads.bib",
+               "texmf/bibtex/bib/refs.bib",
+               "texmf/bibtex/bib/books.bib",
+           ],
+       }
+   ]
+   # Set up bibtex_bibfiles
+   bibtex_bibfiles = []
+
+   # Automatically load local bibfiles in the root directory.
+   for p in Path.cwd().glob("*.bib"):
+       bibtex_bibfiles.append(str(p))
+
+   bibtex_default_style = "lsst_aa"
+   bibtex_reference_style = "author_year"
+
+Create a bibliography and make citations
+========================================
+
+The extension, ``documenteer.ext.githubbibcache``, configures sphinxcontrib-bibtex_ to use the specified BibTeX files from GitHub.
+Now you can use sphinxcontrib-bibtex_ as normal in your documentation project.
+
+First, ensure there's a ``bibliography`` directive in your documentation project:
+
+.. code-block:: rst
+   :caption: index.rst
+
+   References
+   ==========
+
+   .. bibliography::
+
+Then, you can use the citation roles provided by sphinxcontrib-bibtex_.
+
+Regular citations are made with the :rst:role:`cite` role, and textual citations are made with the :rst:role:`cite:t` role:
+
+.. code-block:: rst
+   :caption: index.rst
+
+   Rubin Observatory is a large astronomical survey telescope that will be
+   used to study the Universe :cite:`2019ApJ...873..111I`.
+
+   The Science Book :cite:t:`2009arXiv0912.0201L` describes the science goals
+   of Rubin Observatory.
+
+Clearing the BibTeX cache
+=========================
+
+By default, the extension caches the BibTeX files in a directory called :file:`_build/bibfile-cache` relative to your project's :file:`conf.py` file.
+You can also customize this directory by setting the ``documenteer_bibfile_cache_dir`` variable in :file:`conf.py`.
+For example, Documenteer's technote configuration sets this variable to ``.technote/bibfiles``.
+To get new copies of the bibtex files from GitHub, you can delete the cache directory and rebuild your documentation project.

--- a/docs/sphinx-extensions/index.rst
+++ b/docs/sphinx-extensions/index.rst
@@ -4,13 +4,28 @@ Sphinx extensions
 
 .. toctree::
    :maxdepth: 2
+   :titlesonly:
+   :caption: Referencing & linking
+
+   jira-reference
+   docushare-reference
+   lsst-pybtex-style
+   githubbibcache
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Content tools
+
+   remote-code-block
+   openapi
+   autodocreset
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Science Pipelines
 
    lssttasks
    autocppapi
-   jira-reference
-   docushare-reference
-   remote-code-block
    package-toctree
-   lsst-pybtex-style
-   autodocreset
-   openapi

--- a/docs/sphinx-extensions/lsst-pybtex-style.rst
+++ b/docs/sphinx-extensions/lsst-pybtex-style.rst
@@ -1,12 +1,15 @@
 .. default-domain:: rst
 
-###############################
-BibTeX style extension for LSST
-###############################
+############################################
+BibTeX style extension for Rubin Observatory
+############################################
 
-`sphinxcontrib-bibtex <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/index.html>`_ is an excellent way to include academic citations in Sphinx documentation projects.
-Documenteer provides support for `LSST's common BibTeX bibliography files <https://github.com/lsst/lsst-texmf/tree/master/texmf/bibtex/bib>`__ (maintained in `lsst-texmf <https://github.com/lsst/lsst-texmf>`_) through its ``documenteer.sphinxext.bibtex`` extension.
+sphinxcontrib-bibtex_ is an excellent way to include academic citations in Sphinx documentation projects.
+Documenteer provides support for `LSST's common BibTeX bibliography files <https://github.com/lsst/lsst-texmf/tree/main/texmf/bibtex/bib>`__ (maintained in `lsst-texmf <https://github.com/lsst/lsst-texmf>`__) through its ``documenteer.sphinxext.bibtex`` extension.
 Specifically, this extension provides support for ``docushare`` fields in those bib files.
+
+Usage
+=====
 
 To use this Sphinx extension, add ``documenteer.sphinxext.bibtex`` to your :file:`conf.py` file:
 
@@ -14,23 +17,12 @@ To use this Sphinx extension, add ``documenteer.sphinxext.bibtex`` to your :file
 
    extensions = ["documenteer.sphinxext.bibtex"]
 
-Usage
-=====
+   bibtex_default_style = "lsst_aa"
 
-In your reStructuredText file, declare a bibliography using the ``lsst_aa`` bibliography style:
-
-.. code-block:: rst
-
-   .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
-      :style: lsst_aa
-
-.. note::
-
-   This arrangement of bib file is based on LSST technote projects, which :doc:`vendor the lsst-texmf bib files </technotes/refresh-lsst-bib>`.
-   You will need to customize the bibliography file paths for your own usage.
+The ``bibtex_default_style`` configuration variable configures Sphinx.
 
 Further reading
 ===============
 
-- See `sphinxcontrib-bibtex's Usage documentaton <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#roles-and-directives>`_ to learn how to make citations in reStructuredText documents.
-- For background on maintaining bib files in LSST technote projects, see :doc:`/technotes/refresh-lsst-bib`.
+- See `sphinxcontrib-bibtex's Usage documentation <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#roles-and-directives>`__ to learn how to make citations in reStructuredText documents.
+- For using BibTeX files from the https://github.com/lsst/lsst-texmf repository, see :doc:`githubbibcache`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,13 @@ classifiers = [
 requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
-    "Sphinx",
+    "docutils>=0.20",  # solves an extra div bug with the bibliography directive
+    "Sphinx>=7",  # Consistent docutils constraint
     "PyYAML",
     "GitPython",
     "requests",
     "click",
-    "sphinxcontrib-bibtex>=2.0.0",                  # for pybtex plugin; bibtex_bibfiles config is required.
+    "sphinxcontrib-bibtex>=2.0.0", # for pybtex extension
     "pydantic >= 2.0.0",
     "urllib3",
 ]
@@ -55,10 +56,9 @@ dev = [
 ]
 guide = [
     # Theme and extensions for Rubin user guide projects
-    "sphinx<7",
     "sphinx_design",
     "pydata-sphinx-theme>=0.10.0,<0.13.0",
-    "sphinx-autodoc-typehints<1.23.0",  # avoid requiring Sphinx > 7 only
+    "sphinx-autodoc-typehints",
     "sphinx-automodapi",
     "sphinx-copybutton",
     "sphinx-prompt",
@@ -71,13 +71,11 @@ guide = [
 ]
 technote = [
     # Theme and extensions for technotes
-    "sphinx<7",
     "technote==0.3.0a7",
     "sphinx-prompt",
 ]
 pipelines = [
     # Theme and extensions for pipelines.lsst.io
-    "sphinx<7",
     "lsst-sphinx-bootstrap-theme>=0.2.0,<0.3.0",
     "numpydoc",
     "sphinx-automodapi",

--- a/src/documenteer/conf/technote.py
+++ b/src/documenteer/conf/technote.py
@@ -1,8 +1,25 @@
 """Sphinx configuration for Rubin technotes."""
 
+from pathlib import Path
+
 from technote.sphinxconf import *  # noqa: F401 F403
 
 from documenteer.conf import get_asset_path, get_template_dir
+
+try:
+    extensions.remove("sphinxcontrib.bibtex")  # noqa: F405
+except ValueError:
+    pass
+
+# Add the GitHub bibfile cache extension before sphinxcontrib-bibtex so
+# that it can add bibfiles to the sphinxcontrib-bibtex configuration.
+extensions.extend(  # noqa: F405
+    [
+        "documenteer.sphinxext.bibtex",
+        "documenteer.ext.githubbibcache",
+        "sphinxcontrib.bibtex",
+    ]
+)
 
 html_static_path: list[str] = [
     get_asset_path("rubin-favicon-transparent-32px.png"),
@@ -27,3 +44,28 @@ html_theme_options = {
     "logo_link_url": "https://www.lsst.io",
     "logo_alt_text": "Rubin Observatory logo",
 }
+
+# Configure bibliography with the bib cache
+documenteer_bibfile_cache_dir = ".technote/bibfiles"
+documenteer_bibfile_github_repos = [
+    {
+        "repo": "lsst/lsst-texmf",
+        "ref": "main",
+        "bibfiles": [
+            "texmf/bibtex/bib/lsst.bib",
+            "texmf/bibtex/bib/lsst-dm.bib",
+            "texmf/bibtex/bib/refs_ads.bib",
+            "texmf/bibtex/bib/refs.bib",
+            "texmf/bibtex/bib/books.bib",
+        ],
+    }
+]
+# Set up bibtex_bibfiles
+bibtex_bibfiles = []
+
+# Automatically load local bibfiles in the root directory.
+for p in Path.cwd().glob("*.bib"):
+    bibtex_bibfiles.append(str(p))
+
+bibtex_default_style = "lsst_aa"
+bibtex_reference_style = "author_year"

--- a/src/documenteer/ext/githubbibcache.py
+++ b/src/documenteer/ext/githubbibcache.py
@@ -1,0 +1,132 @@
+"""A Sphinx extension that caches BibTeX files from GitHub repositories.
+
+These bibfiles can be used with sphinxcontrib-bibtex's ``bibliography``
+directive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Self
+
+import requests
+from pydantic import BaseModel, Field
+from sphinx.application import Sphinx
+from sphinx.config import Config
+
+from ..version import __version__
+
+__all__ = ["setup"]
+
+
+class BibRepo(BaseModel):
+    """Model for a configured GitHub repository containing bib files.
+
+    This model corresponds to the ``documenteer_bibfile_github_repos``
+    configuration items.
+    """
+
+    repo: str = Field(
+        ..., description="GitHub repository name", examples=["lsst/texmf"]
+    )
+    ref: str = Field("main", description="GitHub ref (branch or tag)")
+    bibfiles: list[str] = Field(
+        description=(
+            "List of bibfiles in the repo (POSIX paths relative to the root)"
+        ),
+        default_factory=list,
+    )
+
+    @classmethod
+    def parse_config(cls, config: list[dict]) -> list[Self]:
+        return [cls.model_validate(item) for item in config]
+
+    def load_bibfiles(self, cache_dir: Path) -> None:
+        """Load bibfiles from the GitHub repository into the cache directory.
+
+        Parameters
+        ----------
+        cache_dir : `pathlib.Path`
+            Path to the cache directory.
+        """
+        for bib_file in self.bibfiles:
+            cache_path = self.get_cache_path(bib_file, cache_dir)
+            if cache_path.is_file():
+                # Already cached
+                continue
+            self._get_from_github(bib_file, cache_path)
+
+    def get_cached_paths(
+        self, cache_dir: Path, *, exist_only: bool = True
+    ) -> list[Path]:
+        """Return the paths to the locally cached bibfiles from the
+        repository.
+        """
+        paths: list[Path] = []
+        for bib_file in self.bibfiles:
+            p = self.get_cache_path(bib_file, cache_dir)
+            if exist_only and not p.is_file():
+                continue
+            paths.append(p)
+        return paths
+
+    def get_cache_path(self, bib_file: str, cache_dir: Path) -> Path:
+        """Get the local cache path for a bib file."""
+        return cache_dir / self.repo / self.ref / bib_file
+
+    def _get_from_github(self, bib_file: str, cache_path: Path) -> None:
+        url = self._get_raw_url(bib_file)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.unlink(missing_ok=True)
+        r = requests.get(url, allow_redirects=True)
+        r.raise_for_status()
+        content = r.text
+        cache_path.write_text(content)
+
+    def _get_raw_url(self, bib_file: str) -> str:
+        """Get the raw URL for a bib file on GitHub."""
+        return (
+            "https://raw.githubusercontent.com"
+            f"/{self.repo}/{self.ref}/{bib_file}"
+        )
+
+
+def cache_bibfiles(app: Sphinx, config: Config) -> None:
+    """Cache bibfiles from GitHub during config-inited phase."""
+    conf_dir = Path(app.confdir)
+    # Parse the configuration values
+    cache_dir = conf_dir.joinpath(
+        Path(config["documenteer_bibfile_cache_dir"])
+    )
+    repos = BibRepo.parse_config(config["documenteer_bibfile_github_repos"])
+
+    # Load the bibfiles if not in cache
+    for repo in repos:
+        repo.load_bibfiles(cache_dir)
+
+    # Add the bibfiles to the sphinxcontrib-bibtex configuration
+    if "bibtex_bibfiles" not in config:
+        config["bibtex_bibfiles"] = []
+    for repo in repos:
+        for cached_path in repo.get_cached_paths(cache_dir):
+            if cached_path not in config["bibtex_bibfiles"]:
+                config["bibtex_bibfiles"].append(str(cached_path))
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """Set up the ``documenteer.ext.autocppapi`` Sphinx extensions."""
+    # Configuration values
+    app.add_config_value("documenteer_bibfile_github_repos", "", True, [list])
+    app.add_config_value(
+        "documenteer_bibfile_cache_dir",
+        Path("_build/bibfile-cache"),
+        True,
+        [str, Path],
+    )
+    app.connect("config-inited", cache_bibfiles)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/documenteer/templates/technote/sections/sidebar-primary.html
+++ b/src/documenteer/templates/technote/sections/sidebar-primary.html
@@ -1,5 +1,7 @@
+<div class="technote-sidebar-container">
 {% include "components/sidebar-logo.html" %}
 
 {% include "components/sidebar-authors.html" %}
 
 {% include "components/sidebar-source.html" %}
+</div>

--- a/tox.ini
+++ b/tox.ini
@@ -13,12 +13,10 @@ skip_missing_interpreters = True
 [testenv]
 description =
     Run pytest
-    sphinx5: with sphinx 5.*
-    sphinx6: with sphinx 6.*
+    sphinx7: with sphinx 7.*
     sphinxdev: with sphinx master branch
 deps =
-    sphinx5: sphinx==5.*
-    sphinx6: sphinx==6.*
+    sphinx7: sphinx==7.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx
 extras =
     dev
@@ -45,12 +43,11 @@ deps =
     pre-commit
 commands = pre-commit run --all-files
 
-[testenv:typing-sphinx{5,6,dev}]
+[testenv:typing-sphinx{7,dev}]
 description = Run mypy.
 deps =
     mypy
-    sphinx5: sphinx==5.*
-    sphinx6: sphinx==6.*
+    sphinx7: sphinx==7.*
     sphinxdev: git+https://github.com/sphinx-doc/sphinx.git#egg=sphinx
 commands =
     mypy src tests


### PR DESCRIPTION
The new extension, `documenteer.ext.githubbibcache`, can fetch and locally cache bibtex files from one or more public GitHub repositories. These bibfiles are automatically added to `sphinxcontrib-bibtex`'s `bibtex_files` configuration.

Rubin technotes are now configured to automatically cache all bibfiles from the https://github.com/lsst/lsst-texmf repository. The `sphinxcontrib-bibtex` extension is available to technotes as well.

Because of a bug found in docutils <0.20 where it adds an extraneous and unclosed `<div>` element to the page when the `bibliography` directive from sphinxcontrib-bibtex is used, we're now requiring Sphinx>=7 for Documenteer. This in turn enables us to upgrade to docutils 0.20 and later.