### PR TITLE
DM-41781: Update to technote 0.5

### DIFF
--- a/changelog.d/20231128_164718_jsick_DM_41781.md
+++ b/changelog.d/20231128_164718_jsick_DM_41781.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+-
+
+### Bug fixes
+
+-
+
+### Other changes
+
+- Update to technote 0.5. This version fixes support for markdown files and requires structured author names.

--- a/demo/rst-technote/technote.toml
+++ b/demo/rst-technote/technote.toml
@@ -4,12 +4,13 @@ series_id = "SQR"
 canonical_url = "https://sqr-000.lsst.io"
 github_url = "https://github.com/lsst-sqre/sqr-000"
 github_default_branch = "master"
-date_created = "2015-11-18"
-date_updated = "2015-11-23"
+date_created = 2015-11-18
+date_updated = 2015-11-23
 version = "1.0.0"
 
 [[technote.authors]]
-name = { given_names = "Jonathan", family_names = "Sick" }
+name.given = "Jonathan"
+name.family = "Sick"
 orcid = "https://orcid.org/0000-0003-3001-676X"
 affiliations = [
     { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }

--- a/docs/technotes/migrate.rst
+++ b/docs/technotes/migrate.rst
@@ -27,11 +27,12 @@ Here is a simple :file:`technote.toml` file to get you started:
    canonical_url = "https://example-000.lsst.io/"
    github_url = "https://github.com/lsst/example-000"
    github_default_branch = "main"
-   date_created = "2015-11-18"
-   date_updated = "2023-11-01"
+   date_created = 2015-11-18
+   date_updated = 2023-11-01
 
    [[technote.authors]]
-   name = { given_names = "Drew", family_names = "Developer" }
+   name.given = "Drew"
+   name.family = "Developer"
    orcid = "https://orcid.org/0000-0001-2345-6789"
    affiliations = [
        { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ pipelines = [
 ]
 technote = [
     # Theme and extensions for technotes
-    "technote>=0.4.0,<0.5.0",
+    "technote>=0.5.0,<0.6.0",
     "sphinx-prompt",
 ]
 


### PR DESCRIPTION
This version of technote changes the `technote.toml` keys for describing names. 