### PR TITLE
DM-42023: Add documenteer technote add-author and sync-authors commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v4.5.0
     hooks:
       - id: check-yaml
+        exclude: ^src/documenteer/storage/localtemplates/technote/ci\.yaml
       - id: check-toml
       - id: check-json
       - id: trailing-whitespace

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft src/documenteer/assets
 graft src/documenteer/assets/scripts
 graft src/documenteer/assets/rsd-assets
+graft src/documenteer/storage/localtemplates

--- a/changelog.d/20231212_141904_jsick_DM_42023.md
+++ b/changelog.d/20231212_141904_jsick_DM_42023.md
@@ -1,0 +1,7 @@
+### New features
+
+- New command-line interface for technote authors.
+
+  - `documenteer technote migrate` automates to the process of migrating an old technote to the new format.
+  - `documenteer technote add-author` adds an author to a technote's `technote.toml` file using data from the `authordb.yaml` file in https://github.com/lsst/lsst-texmf.
+  - `documenteer technote sync-authors` refreshing author information in a `technote.toml` file with information from the `authordb.yaml` file. This requires that individual authors have `internal_id` fields to correlate with `authordb.yaml`.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -60,6 +60,8 @@
 .. _Technote: https://technote.lsst.io/
 .. _`myst_parser`: https://myst-parser.readthedocs.io/en/latest/index.html
 .. _sphinx.ext.intersphinx: https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+.. _`authordb.yaml`: https://github.com/lsst/lsst-texmf/blob/main/etc/authordb.yaml
+.. _pipx: https://pipx.pypa.io
 
 .. Internal links
 

--- a/docs/technotes/migrate.rst
+++ b/docs/technotes/migrate.rst
@@ -2,8 +2,8 @@
 Migrate legacy Sphinx technical notes
 #####################################
 
-Introduced in November 2023, Rubin Observatory has a new technical note format for Markdown and reStructuredText documents, based on the Sphinx_ and the `Technote <https://technote.lsst.io>`__ Python packages.
-If your started writing your technical note before November 2023, it is likely in the legacy Sphinx format.
+Introduced in December 2023, Rubin Observatory has a new technical note format for Markdown and reStructuredText documents, based on the Sphinx_ and `Technote <https://technote.lsst.io>`__ Python packages.
+If you started writing your technical note before December 2023, it is likely in the legacy Sphinx format.
 You can tell if your technical note is in the legacy format if it has a :file:`metadata.yaml` file.
 If you are continuing to write such a technical note, you should migrate it to the new format to take advantage of new features.
 This page provides a guide to migrating your technical note to the new format.
@@ -11,8 +11,78 @@ This page provides a guide to migrating your technical note to the new format.
 To get started on your migration, be sure to have your technote repository checked-out locally.
 Work on a ticket branch, `per the Developer Guide <https://developer.lsst.io/work/flow.html>`__, so you can check your work with a pull request before merging to the ``main`` branch.
 
+Running the migration tool
+==========================
+
+Documenteer provides a migration tool, :command:`documenteer technote migrate`, that can help automate this process.
+
+If you cannot use this tool, you can follow the `detailed steps <#technote-migration-detailed>`__ below.
+For example, if you have a customized build process, you may want to manually migrate your technote.
+Alternatively you can run the migration tool, and then use Git to unstage any changes you don't want to commit.
+
+Preparation
+-----------
+
+To run the migration command in an isolated Python environment, without affecting other projects, you can use the ``pipx`` tool.
+First, install ``pipx``:
+
+.. tab-set::
+
+   .. tab-item:: pip
+
+      .. prompt:: bash
+
+         python -m pip install pipx
+
+   .. tab-item:: conda-forge
+
+      .. prompt:: bash
+
+         conda install -c conda-forge pipx
+
+   .. tab-item:: homebrew
+
+      .. prompt:: bash
+
+         brew install pipx
+
+.. important::
+
+   Documenteer, and therefore pipx, need Python 3.11 or later.
+
+Run the migration
+-----------------
+
+From the root of the cloned technote repository, you can run the migration tool:
+
+.. prompt:: bash
+
+   pipx run documenteer technote migrate
+
+.. tip::
+
+   You can also add author information during the migration.
+   Open `authordb.yaml`_ on GitHub and find the keys that identify the technote's authors.
+   For example, ``sickj`` is the key for Jonathan Sick.
+   Then run the migration command with a ``-a`` option for each author:
+
+   .. prompt:: bash
+
+      pipx run documenteer technote migrate -a sickj -a economouf
+
+When the migration runs, it shows a summary of the files changed and deleted.
+Use ``git diff`` to see the changes in detail.
+You may want to tweak those changes before committing them.
+
+If you want to learn more about the changes made by the migration tool, you can review the :ref:`detailed steps below <technote-migration-detailed>`.
+
+.. _technote-migration-detailed:
+
+Detailed steps
+==============
+
 Step 1. Create a technote.toml file
-===================================
+-----------------------------------
 
 The :file:`technote.toml` file replaces the original :file:`metadata.yaml` file.
 This new file provides both metadata and Sphinx configuration for your document.
@@ -31,22 +101,36 @@ Here is a simple :file:`technote.toml` file to get you started:
    date_updated = 2023-11-01
 
    [[technote.authors]]
-   name.given = "Drew"
-   name.family = "Developer"
+   name = {given = "Drew", family = "Developer"}
+   internal_id = "example"
    orcid = "https://orcid.org/0000-0001-2345-6789"
-   affiliations = [
-       { name = "Rubin Observatory", ror = "https://ror.org/048g3cy84" }
-   ]
+   [[technote.authors.affiliations]]
+   name = "Rubin Observatory Project Office"
+   internal_id = "RubinObs"
 
-Add this file to your repository and commit it:
+When you're done, add this file to your repository and commit it:
 
 .. prompt:: bash
 
    git add technote.toml
    git commit -m "Add technote.toml file"
 
+.. note::
+
+   The schema for this file is described in the `Technote package documentation <https://technote.lsst.io/user-guide/technote-toml.html>`__, and elsewhere in the :doc:`Documenteer documentation for Rubin technotes <index>`.
+   For now, some pointers on important metadata:
+
+   - ``id`` is the technote's handle. A lower-cased version of the handle is the subdomain of the technote's website.
+     For example, the handle for https://sqr-000.lsst.io/ is ``SQR-000``.
+   - ``series_id`` is the technote's series handle. At Rubin, this is the handle's prefix. Common series include ``RTN``, ``DMTN``, ``SQR``, and ``SITCOMTN``.
+   - ``canonical_url`` is the URL of the technote's website.
+   - ``github_url`` is the URL of the technote's GitHub repository.
+   - ``date_created`` is an optional field that specifies when the technote was first created.
+   - ``date_updated`` is an optional field that specifies when the technote was last updated. If you omit this field, the current date is used.
+   - Each author is specified with a ``[[technote.authors]]`` table (in TOML, the double brackets represent a table in an **array of tables**). Use the :command:`mamke add-author` command to add an author to this file using data from `authordb.yaml`_. It's important to use the ``internal_id`` field to identify authors with their corresponding key in `authordb.yaml`_. This enables Documenteer to update author information with the :command:`make sync-authors` command.
+
 Step 2. Update conf.py
-======================
+----------------------
 
 The :file:`conf.py` file directly configures the Sphinx build process.
 New technotes use a different configuration set provided by Documenteer that uses :file:`technote.toml` to customize the Sphinx configuration.
@@ -67,7 +151,7 @@ If your :file:`conf.py` file has additional content, some of that configuration 
 Reach out to `#dm-docs-support`_ on Slack for advice.
 
 Step 3. Update the index.rst file
-=================================
+---------------------------------
 
 The :file:`index.rst` file is the main content file for your technical note.
 The new technote format requires some changes to this file: the title is now part of the content, the abstract is marked up with a directive, status information is now part of :file:`technote.toml`, and the configuration for the reference section is dramatically simplified.
@@ -90,7 +174,7 @@ The new technote format requires some changes to this file: the title is now par
       git commit -m "Switch to Markdown format"
 
 Add the title
--------------
+~~~~~~~~~~~~~
 
 The title is now part of the content, not the metadata.
 Add the title to the top of the content:
@@ -116,14 +200,14 @@ Add the title to the top of the content:
          # Example technical note
 
 Move document status information to technote.toml
--------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The original technote format used a ``note`` directive to describe whether the document was a draft or deprecated.
 Now this status metadata is structured in :file:`technote.toml`.
 Delete the ``note`` directive and add the status information to :file:`technote.toml` following :doc:`document-status`.
 
 Format the abstract/summary with the abstract directive
--------------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Legacy technotes either provided an abstract or summary through the ``description`` field in :file:`metadata.yaml`, in a ``note`` directive in :file:`index.rst`, or in a content section in :file:`index.rst`.
 The new technote format uses an ``abstract`` directive to mark up the abstract/summary.
@@ -166,7 +250,7 @@ The new technote format uses an ``abstract`` directive to mark up the abstract/s
          [... content below ...]
 
 Simplify the reference section
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If your technote makes references to other documents with roles like :external+sphinxcontrib-bibtex:rst:role:`cite`, you'll need a reference section to display the bibliography.
 In the new technote format, this section is simplified:
@@ -203,7 +287,7 @@ Specifically:
 - The bibliography directive no longer requires any configuration; all configuration is provided by Documenteer.
 
 Commit any changes
-------------------
+~~~~~~~~~~~~~~~~~~
 
 .. tab-set::
 
@@ -222,7 +306,7 @@ Commit any changes
          git commit -m "Reformat index.md for new technote format"
 
 Step 4. Delete metadata.yaml
-============================
+----------------------------
 
 At this point, all relevant metadata about the technote is in :file:`technote.toml` or :file:`index.rst`/:file:`index.md`.
 Delete the deprecated :file:`metadata.yaml` file:
@@ -233,7 +317,7 @@ Delete the deprecated :file:`metadata.yaml` file:
    git commit -m "Remove metadata.yaml file"
 
 Step 5. Delete the lsstbib/ directory
-=====================================
+-------------------------------------
 
 The legacy technote format vendored Rubin BibTeX bibliography files from https://github.com/lsst/lsst-texmf.
 The new technote format automatically downloads and caches these files so that you no longer need to commit them into your repository.
@@ -245,7 +329,7 @@ Delete the :file:`lsstbib` directory:
    git commit -m "Remove lsstbib/ directory"
 
 Step 6. Update .gitignore
-=========================
+-------------------------
 
 The new technote format introduces additional directories that should be ignored by Git.
 Ensure at least the following paths are included in the :file:`.gitignore` file:
@@ -265,7 +349,7 @@ Ensure at least the following paths are included in the :file:`.gitignore` file:
    git commit -m "Update .gitignore file"
 
 Step 7. Set up pre-commit hooks
-===============================
+-------------------------------
 
 Pre-commit_ is a Python package that runs validation and formatting checks on your technote's repository before you commit.
 Although it is not required, it's highly recommended that you set up pre-commit hooks for your technote.
@@ -294,8 +378,8 @@ Commit any changes:
    You can add additional pre-commit hooks to this file to suite your needs.
    See Pre-commit's `directory of available hooks <https://pre-commit.com/hooks.html>`__ for ideas.
 
-Step 6. Update requirements.txt
-===============================
+Step 8. Update requirements.txt
+-------------------------------
 
 The Python dependencies for your technote are listed in a :file:`requirements.txt` file that should now look like this:
 
@@ -315,8 +399,8 @@ Commit any changes:
 
    If your technote has additional dependencies listed, you can reach out to `#dm-docs-support`_ on Slack if you are unsure whether they are part of the Sphinx build process or separate packages needed for any custom document preprocessing.
 
-Step 7. Add a tox.ini file
-==========================
+Step 9. Add a tox.ini file
+--------------------------
 
 Tox_ is a tool for running Python programs in dedicated virtual environments.
 This makes your local technote builds more reproducible by separating the technote's dependencies from your system and other projects.
@@ -347,8 +431,8 @@ This is the recommended tox configuration to start with:
    commands =
       pre-commit run --all-files
 
-Step 7. Update the Makefile
-===========================
+Step 10. Update the Makefile
+----------------------------
 
 The :file:`Makefile` file provides a simple entrypoint for building your technote and performing other common tasks.
 This is the suggested content for your :file:`Makefile` that works with the tox and pre-commit configurations:
@@ -374,8 +458,8 @@ This is the suggested content for your :file:`Makefile` that works with the tox 
    	rm -rf .technote
    	rm -rf .tox
 
-Step 8. Update GitHub Actions workflows
-=======================================
+Step 11. Update GitHub Actions workflows
+----------------------------------------
 
 Recent technotes have already migrated their GitHub Actions workflows to use the reusable workflow from https://github.com/lsst-sqre/rubin-sphinx-technote-workflows.
 Check the :file:`.github/workflows/ci.yaml` file to make sure it looks like this:
@@ -418,8 +502,8 @@ If necessary, commit any changes:
       git rm .travis.yml
       git commit -m "Remove Travis configuration"
 
-Step 9. Add dependabot support
-==============================
+Step 12. Add dependabot support
+-------------------------------
 
 Dependabot is a service provided by GitHub that generates pull requests when there are new versions of your technote's dependencies.
 Set up Dependabot by adding a :file:`.github/dependabot.yml` file:
@@ -446,8 +530,8 @@ Commit the changes:
    git add .github/dependabot.yml
    git commit -m "Add dependabot configuration"
 
-Step 10. Update the README
-==========================
+Step 13. Update the README
+--------------------------
 
 The README for a legacy-format technote likely has outdated information about how to build the technote.
 Here is a suggested README template for technotes in the new format:
@@ -480,8 +564,8 @@ Here is a suggested README template for technotes in the new format:
          git add README.md
          git commit -m "Update README for new technote format"
 
-Step 11. Merge the migration
-============================
+Step 14. Merge the migration
+----------------------------
 
 At this point, you should have a working technote in the new format.
 If you haven't already, push your branch to the GitHub repository and open a pull request.

--- a/docs/technotes/migrate.rst
+++ b/docs/technotes/migrate.rst
@@ -334,14 +334,9 @@ Step 6. Update .gitignore
 The new technote format introduces additional directories that should be ignored by Git.
 Ensure at least the following paths are included in the :file:`.gitignore` file:
 
-.. code-block:: text
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/gitignore
+   :language: text
    :caption: .gitignore
-
-   _build
-   .technote
-   .tox
-   venv
-   .venv
 
 .. prompt:: bash
 
@@ -355,16 +350,9 @@ Pre-commit_ is a Python package that runs validation and formatting checks on yo
 Although it is not required, it's highly recommended that you set up pre-commit hooks for your technote.
 To start, add a :file:`.pre-commit-config.yaml` file:
 
-.. code-block:: yaml
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/pre-commit-config.yaml
+   :language: yaml
    :caption: .pre-commit-config.yaml
-
-   repos:
-     - repo: https://github.com/pre-commit/pre-commit-hooks
-       rev: v4.5.0
-       hooks:
-         - id: trailing-whitespace
-         - id: check-yaml
-         - id: check-toml
 
 Commit any changes:
 
@@ -383,10 +371,9 @@ Step 8. Update requirements.txt
 
 The Python dependencies for your technote are listed in a :file:`requirements.txt` file that should now look like this:
 
-.. code-block:: text
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/requirements.txt
+   :language: text
    :caption: requirements.txt
-
-   documenteer[technote]>=1.0.0,<2.0.0
 
 Commit any changes:
 
@@ -407,29 +394,9 @@ This makes your local technote builds more reproducible by separating the techno
 
 This is the recommended tox configuration to start with:
 
-.. code-block:: ini
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/tox.ini
+   :language: ini
    :caption: tox.ini
-
-   [tox]
-   environments = html
-   isolated_build = True
-
-   [testenv]
-   skip_install = true
-   deps =
-       -rrequirements.txt
-
-   [testenv:html]
-   commands =
-      sphinx-build --keep-going -n -W -T -b html -d {envtmpdir}/doctrees . _build/html
-
-   [testenv:linkcheck]
-   commands =
-      sphinx-build --keep-going -n -W -T -b linkcheck -d {envtmpdir}/doctrees . _build/linkcheck
-
-   [testenv:lint]
-   commands =
-      pre-commit run --all-files
 
 Step 10. Update the Makefile
 ----------------------------
@@ -437,26 +404,9 @@ Step 10. Update the Makefile
 The :file:`Makefile` file provides a simple entrypoint for building your technote and performing other common tasks.
 This is the suggested content for your :file:`Makefile` that works with the tox and pre-commit configurations:
 
-.. code-block:: Makefile
-
-   .PHONY:
-   init:
-   	pip install tox pre-commit
-   	pre-commit install
-
-   .PHONY:
-   html:
-   	tox run -e html
-
-   .PHONY:
-   lint:
-   	tox run -e lint,link-check
-
-   .PHONY:
-   clean:
-   	rm -rf _build
-   	rm -rf .technote
-   	rm -rf .tox
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/Makefile
+   :language: make
+   :caption: Makefile
 
 Step 11. Update GitHub Actions workflows
 ----------------------------------------
@@ -508,20 +458,9 @@ Step 12. Add dependabot support
 Dependabot is a service provided by GitHub that generates pull requests when there are new versions of your technote's dependencies.
 Set up Dependabot by adding a :file:`.github/dependabot.yml` file:
 
-.. code-block:: yaml
+.. literalinclude:: ../../src/documenteer/storage/localtemplates/technote/dependabot.yml
+   :language: yaml
    :caption: .github/dependabot.yml
-
-   version: 2
-   updates:
-     - package-ecosystem: "github-actions"
-       directory: "/"
-       schedule:
-         interval: "weekly"
-
-     - package-ecosystem: "pip"
-       directory: "/"
-       schedule:
-         interval: "weekly"
 
 Commit the changes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ Homepage = "https://documenteer.lsst.io"
 Source = "https://github.com/lsst-sqre/documenteer"
 
 [project.scripts]
+documenteer = "documenteer.cli:main"
 stack-docs = "documenteer.stackdocs.stackcli:main"
 package-docs = "documenteer.stackdocs.packagecli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pydantic >= 2.0.0",
     "urllib3",
     "pylatexenc",
+    "tomlkit",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "sphinxcontrib-bibtex>=2.0.0", # for pybtex extension
     "pydantic >= 2.0.0",
     "urllib3",
+    "pylatexenc",
 ]
 
 [project.optional-dependencies]

--- a/src/documenteer/cli.py
+++ b/src/documenteer/cli.py
@@ -154,7 +154,17 @@ def technote_sync_authors(technote_toml: str) -> None:
     default=".",
     help="Path to technote directory",
 )
-def technote_migrate(author_ids: list[str], root_dir: str) -> None:
+@click.option(
+    "--auto-delete",
+    "-D",
+    "auto_delete",
+    is_flag=True,
+    default=False,
+    help="Delete deprecated files without prompting",
+)
+def technote_migrate(
+    author_ids: list[str], root_dir: str, auto_delete: bool
+) -> None:
     """Migrate a technote from a metadata.yaml file.
 
     This command migrates an old-style Rubin technote (that uses a
@@ -171,3 +181,6 @@ def technote_migrate(author_ids: list[str], root_dir: str) -> None:
     author_db = AuthorDb.download()
     migration_service = TechnoteMigrationService(Path(root_dir), author_db)
     migration_service.migrate(author_ids=author_ids)
+
+    if auto_delete or click.confirm("Delete deprecated files?"):
+        migration_service.delete_deprecated_files()

--- a/src/documenteer/cli.py
+++ b/src/documenteer/cli.py
@@ -1,0 +1,60 @@
+"""Documenteer's command-line interface (CLI)."""
+
+from __future__ import annotations
+
+import click
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(message="%(version)s")
+def main() -> None:
+    """Documenteer command-line tools.
+
+    You can learn more at https://documenteer.lsst.io/
+    """
+
+
+# display_help is vendored from safir.click.
+
+
+def display_help(
+    main: click.Group,
+    ctx: click.Context,
+    topic: str | None = None,
+    subtopic: str | None = None,
+) -> None:
+    """Show help for a Click command."""
+    if not topic:
+        if not ctx.parent:
+            raise RuntimeError("help called without topic or parent")
+        click.echo(ctx.parent.get_help())
+        return
+    if topic not in main.commands:
+        raise click.UsageError(f"Unknown help topic {topic}", ctx)
+    if not subtopic:
+        ctx.info_name = topic
+        click.echo(main.commands[topic].get_help(ctx))
+        return
+
+    # Subtopic handling. This requires some care with typing, since the
+    # commands attribute (although present) is not documented, and the
+    # get_command method is only available on MultiCommands.
+    group = main.commands[topic]
+    if isinstance(group, click.MultiCommand):
+        command = group.get_command(ctx, subtopic)
+        if command:
+            ctx.info_name = f"{topic} {subtopic}"
+            click.echo(command.get_help(ctx))
+            return
+
+    # Fall through to the error case of no subcommand found.
+    msg = f"Unknown help topic {topic} {subtopic}"
+    raise click.UsageError(msg, ctx)
+
+
+@main.command()
+@click.argument("topic", default=None, required=False, nargs=1)
+@click.pass_context
+def help(ctx: click.Context, topic: str | None) -> None:
+    """Show help for any command."""
+    display_help(main, ctx, topic)

--- a/src/documenteer/cli.py
+++ b/src/documenteer/cli.py
@@ -73,7 +73,14 @@ def technote() -> None:
 
 
 @technote.command(name="add-author")
-@click.argument("author_id", nargs=1, required=True)
+@click.option(
+    "-a",
+    "--author-id",
+    "author_id",
+    nargs=1,
+    required=True,
+    prompt="Author ID",
+)
 @click.option(
     "--toml",
     "-t",
@@ -94,10 +101,10 @@ def technote_add_author(author_id: str, technote_toml: str) -> None:
 
     service = TechnoteAuthorService(toml_file, author_db)
     author = service.add_author_by_id(author_id)
-    service.write_toml(toml_path)
     print(
         f"Added author {author.given_name} {author.family_name} to {toml_path}"
     )
+    service.write_toml(toml_path)
 
 
 @technote.command(name="sync-authors")

--- a/src/documenteer/services/__init__.py
+++ b/src/documenteer/services/__init__.py
@@ -1,0 +1,1 @@
+"""Documenteer services."""

--- a/src/documenteer/services/technoteauthor.py
+++ b/src/documenteer/services/technoteauthor.py
@@ -1,0 +1,48 @@
+"""A service for maintaining authors in a technote.toml file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from documenteer.storage.authordb import AuthorDb, AuthorInfo
+from documenteer.storage.technotetoml import TechnoteTomlFile
+
+
+class TechnoteAuthorService:
+    """A service for maintaining authors in a technote.toml file."""
+
+    def __init__(
+        self, toml_file: TechnoteTomlFile, author_db: AuthorDb
+    ) -> None:
+        self.toml_file = toml_file
+        self.author_db = author_db
+
+    def add_author_by_id(self, toml_path: Path, author_id: str) -> AuthorInfo:
+        """Add an author to the technote.toml file."""
+        try:
+            author = self.author_db.get_author(author_id)
+        except KeyError:
+            raise ValueError(f"Author {author_id} not found in authordb.yaml")
+
+        self.toml_file.upsert_author(author)
+        self.toml_file.save(toml_path)
+
+        return author
+
+    def sync_authors(self, toml_path: Path) -> list[AuthorInfo]:
+        """Synchronize author info from authordb.yaml."""
+        new_authors: list[AuthorInfo] = []
+
+        for author_id in self.toml_file.author_ids:
+            try:
+                author = self.author_db.get_author(author_id)
+                new_authors.append(author)
+            except KeyError:
+                raise ValueError(
+                    f"Author {author_id} not found in authordb.yaml"
+                )
+            self.toml_file.upsert_author(author)
+
+        self.toml_file.save(toml_path)
+
+        return new_authors

--- a/src/documenteer/services/technoteauthor.py
+++ b/src/documenteer/services/technoteauthor.py
@@ -17,7 +17,11 @@ class TechnoteAuthorService:
         self.toml_file = toml_file
         self.author_db = author_db
 
-    def add_author_by_id(self, toml_path: Path, author_id: str) -> AuthorInfo:
+    def write_toml(self, path: Path) -> None:
+        """Write the technote.toml file."""
+        self.toml_file.save(path)
+
+    def add_author_by_id(self, author_id: str) -> AuthorInfo:
         """Add an author to the technote.toml file."""
         try:
             author = self.author_db.get_author(author_id)
@@ -25,24 +29,21 @@ class TechnoteAuthorService:
             raise ValueError(f"Author {author_id} not found in authordb.yaml")
 
         self.toml_file.upsert_author(author)
-        self.toml_file.save(toml_path)
 
         return author
 
-    def sync_authors(self, toml_path: Path) -> list[AuthorInfo]:
+    def sync_authors(self) -> list[AuthorInfo]:
         """Synchronize author info from authordb.yaml."""
-        new_authors: list[AuthorInfo] = []
+        updated_authors: list[AuthorInfo] = []
 
         for author_id in self.toml_file.author_ids:
             try:
                 author = self.author_db.get_author(author_id)
-                new_authors.append(author)
+                updated_authors.append(author)
             except KeyError:
                 raise ValueError(
                     f"Author {author_id} not found in authordb.yaml"
                 )
             self.toml_file.upsert_author(author)
 
-        self.toml_file.save(toml_path)
-
-        return new_authors
+        return updated_authors

--- a/src/documenteer/services/technotemigration.py
+++ b/src/documenteer/services/technotemigration.py
@@ -228,3 +228,32 @@ class TechnoteMigrationService:
             context=context,
         )
         print("✅ tox.ini")
+
+    def delete_deprecated_files(self) -> None:
+        """Delete deprecated files."""
+        deprecated_files = [
+            "metadata.yaml",
+            ".travis.yml",
+        ]
+        for file in deprecated_files:
+            path = self.root_dir / file
+            self._delete_file(path)
+
+        deprecated_dirs = [
+            "lsstbib",
+        ]
+        for dirname in deprecated_dirs:
+            path = self.root_dir / dirname
+            self._delete_directory(path)
+
+    def _delete_file(self, path: Path) -> None:
+        """Delete a file."""
+        if path.exists():
+            path.unlink()
+            print(f"❌ {path}")
+
+    def _delete_directory(self, path: Path) -> None:
+        """Delete a directory."""
+        if path.exists():
+            path.rmdir()
+            print(f"❌ {path}")

--- a/src/documenteer/services/technotemigration.py
+++ b/src/documenteer/services/technotemigration.py
@@ -1,0 +1,128 @@
+"""Technote migration service."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from documenteer.storage.authordb import AuthorDb
+from documenteer.storage.technotetoml import TechnoteTomlFile
+
+from .technoteauthor import TechnoteAuthorService
+
+
+class TechnoteMigrationService:
+    """A service for migrating technotes to the new Technote-based format."""
+
+    def __init__(self, technote_dir: Path, author_db: AuthorDb) -> None:
+        self.root_dir = technote_dir
+        self.author_db = author_db
+
+    def migrate(self, *, author_ids: list[str]) -> None:
+        """Migrate a technote.yaml to technote.toml."""
+        yaml_path = self.root_dir / "metadata.yaml"
+        toml_path = self.root_dir / "technote.toml"
+        original_metadata = yaml.safe_load(yaml_path.read_text())
+
+        toml_file = self._create_toml_file(original_metadata)
+        toml_file.save(toml_path)
+
+        # Add authors
+        author_service = TechnoteAuthorService(toml_file, self.author_db)
+        for author_id in author_ids:
+            try:
+                author_service.add_author_by_id(author_id)
+            except ValueError:
+                print(
+                    f"Warning: Author {author_id} not found in authordb.yaml"
+                )
+        toml_file.save(self.root_dir / "technote.toml")
+
+        content = self._upgrade_content(original_metadata)
+        self.root_dir.joinpath("index.rst").write_text(content)
+
+    def _create_toml_file(
+        self, original_metadata: dict[str, Any]
+    ) -> TechnoteTomlFile:
+        """Create a technote.toml file."""
+        try:
+            github_url = original_metadata["github_url"]
+        except KeyError:
+            raise ValueError("metadata.yaml does not contain github_url")
+
+        try:
+            number = original_metadata["serial_number"]
+        except KeyError:
+            raise ValueError("metadata.yaml does not contain serial_number")
+
+        try:
+            series = original_metadata["series"]
+        except KeyError:
+            raise ValueError("metadata.yaml does not contain series")
+
+        toml_content = (
+            "[technote]\n"
+            f'id = "{series}-{number}"\n'
+            f'series_id = "{series}"\n'
+            f'canonical_url = "https://{series.lower()}-{number}.lsst.io/"\n'
+            f'github_url = "{github_url}"\n'
+            f'github_default_branch = "main"\n'
+        )
+
+        return TechnoteTomlFile(toml_content)
+
+    def _upgrade_content(self, original_metadata: dict[str, Any]) -> str:
+        """Upgrade index.rst."""
+        index_rst_path = self.root_dir / "index.rst"
+        if not index_rst_path.exists():
+            raise RuntimeError("index.rst does not exist")
+        rst_content = index_rst_path.read_text()
+
+        # Add title
+        try:
+            title = original_metadata["doc_title"]
+        except KeyError:
+            raise ValueError("metadata.yaml does not contain doc_title")
+        underlines = "#" * len(title)
+        rst_title = f"{underlines}\n{title}\n{underlines}\n\n"
+
+        # Add abstract
+        try:
+            abstract = original_metadata["description"]
+        except KeyError:
+            raise ValueError("metadata.yaml does not contain a description")
+        rst_abstract = f".. abstract::\n\n   {abstract}\n\n"
+
+        # Filter out lines of content with old formatting concerns
+        lines = rst_content.splitlines()
+        # Patterns for lines that should be dropped
+        drop_lines = [
+            r"^:tocdepth:",
+            r"^\.\. Please do not modify tocdepth",
+            r"\.\. sectnum::",
+            r"^   :style: lsst_aa",
+        ]
+        new_lines: list[str] = []
+        for line in lines:
+            if not any([re.match(p, line) for p in drop_lines]):
+                new_lines.append(line)
+
+        # Replace lines related to the bibliography
+        replacements = [
+            (
+                r"^\.\. rubric:: References",
+                "References\n==========\n",
+            ),
+            (r"^\.\. bibliography::", ".. bibliography::\n"),
+        ]
+        for pattern, replacement in replacements:
+            new_lines = [
+                replacement if re.match(pattern, line) else line
+                for line in new_lines
+            ]
+
+        # Prepend title and abstract
+        return rst_title + rst_abstract + "\n".join(new_lines)

--- a/src/documenteer/storage/__init__.py
+++ b/src/documenteer/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Data storage interfaces."""

--- a/src/documenteer/storage/authordb.py
+++ b/src/documenteer/storage/authordb.py
@@ -1,0 +1,151 @@
+"""Storage interface for lsst-texmf's authordb.yaml file."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import requests
+import yaml
+from pydantic import BaseModel, Field, RootModel
+
+from .latex import Latex
+
+# latex = "... LaTeX code ..."
+# text = LatexNodes2Text().latex_to_text(latex)
+
+
+class AuthorDbAuthor(BaseModel):
+    """Model for an author entry in author.yaml file."""
+
+    name: str = Field(description="Author's family name")
+
+    initials: str = Field(description="Author's given name")
+
+    affil: list[str] = Field(default_factory=list, description="Affiliations")
+
+    orcid: str | None = Field(
+        default=None,
+        description="Author's ORCiD identifier (optional)",
+    )
+
+
+class AuthorDbAuthors(RootModel):
+    """Model for the authors mapping in authordb.yaml file."""
+
+    root: Dict[str, AuthorDbAuthor]
+
+    def __getitem__(self, author_id: str) -> AuthorDbAuthor:
+        """Get an author entry by ID."""
+        return self.root[author_id]
+
+
+class AuthorDbYaml(BaseModel):
+    """Model for the authordb.yaml file in lsst/lsst-texmf."""
+
+    affiliations: dict[str, str] = Field(
+        description=(
+            "Mapping of affiliation IDs to affiliation names. Affiliations "
+            "are their name, a comma, and thier address."
+        )
+    )
+
+    authors: AuthorDbAuthors = Field(
+        description="Mapping of author IDs to author information"
+    )
+
+
+@dataclass
+class AuthorInfo:
+    """Consolidated author information."""
+
+    author_id: str
+    given_name: str
+    family_name: str
+    orcid: str
+    affiliation_name: str
+    affiliation_id: str
+    affiliation_address: str
+
+    @classmethod
+    def create_from_db(
+        cls,
+        author_id: str,
+        db_author: AuthorDbAuthor,
+        db_affils: dict[str, str],
+    ) -> AuthorInfo:
+        """Create an AuthorInfo from an AuthorDbAuthor and affiliations."""
+        # Transform orcid path to a full orcid.org URL
+        if db_author.orcid:
+            if db_author.orcid.startswith("http"):
+                orcid = db_author.orcid
+            else:
+                orcid = f"https://orcid.org/{db_author.orcid}"
+        else:
+            orcid = ""
+
+        # Transform the first affiliation
+        if db_author.affil:
+            affiliation_id = db_author.affil[0]
+            affil = db_affils[affiliation_id]
+            parts = affil.split(",")
+            affiliation_name = parts[0]
+            if len(parts) > 1:
+                address_parts = [p.strip() for p in parts[1:]]
+                affiliation_address = ", ".join(address_parts)
+            else:
+                affiliation_address = ""
+        else:
+            affiliation_id = ""
+            affiliation_name = ""
+            affiliation_address = ""
+
+        # Convert LaTeX to text
+        affiliation_name = Latex(affiliation_name).to_text()
+        affiliation_address = Latex(affiliation_address).to_text()
+        given_name = Latex(db_author.initials).to_text()
+        family_name = Latex(db_author.name).to_text()
+
+        return cls(
+            author_id=author_id,
+            given_name=given_name,
+            family_name=family_name,
+            orcid=orcid,
+            affiliation_name=affiliation_name,
+            affiliation_id=affiliation_id,
+            affiliation_address=affiliation_address,
+        )
+
+
+class AuthorDb:
+    """An interface for the lsst/lsst-texmf authordb.yaml file content."""
+
+    def __init__(self, data: AuthorDbYaml) -> None:
+        """Initialize the interface."""
+        self._data = data
+
+    @classmethod
+    def from_yaml(cls, yaml_data: str) -> AuthorDb:
+        """Create an AuthorDb from a string of YAML data."""
+        return cls(AuthorDbYaml.model_validate(yaml.safe_load(yaml_data)))
+
+    @classmethod
+    def download(cls) -> AuthorDb:
+        """Download a authordb.yaml from GitHub."""
+        url = (
+            "https://raw.githubusercontent.com/lsst/lsst-texmf"
+            "/main/etc/authordb.yaml"
+        )
+        r = requests.get(url)
+        r.raise_for_status()
+        yaml_data = r.text
+        return cls.from_yaml(yaml_data)
+
+    def get_author(self, author_id: str) -> AuthorInfo:
+        """Get an author entry by ID."""
+        # return self._data.authors[author_id]
+        db_author = self._data.authors[author_id]
+        db_affiliations = {
+            k: self._data.affiliations[k] for k in db_author.affil
+        }
+        return AuthorInfo.create_from_db(author_id, db_author, db_affiliations)

--- a/src/documenteer/storage/authordb.py
+++ b/src/documenteer/storage/authordb.py
@@ -99,7 +99,7 @@ class AuthorInfo:
     author_id: str
     given_name: str
     family_name: str
-    orcid: str
+    orcid: str | None
     affiliations: list[AffiliationInfo]
 
     @classmethod
@@ -117,7 +117,7 @@ class AuthorInfo:
             else:
                 orcid = f"https://orcid.org/{db_author.orcid}"
         else:
-            orcid = ""
+            orcid = None
 
         affiliations: list[AffiliationInfo] = []
         for affiliation_id in db_author.affil:

--- a/src/documenteer/storage/latex.py
+++ b/src/documenteer/storage/latex.py
@@ -1,0 +1,22 @@
+"""Utilities for handling LaTeX text content."""
+
+from __future__ import annotations
+
+import re
+
+from pylatexenc.latex2text import LatexNodes2Text
+
+__all__ = ["Latex"]
+
+
+class Latex:
+    """A class for handling LaTeX text content."""
+
+    def __init__(self, tex: str) -> None:
+        self.tex = tex
+
+    def to_text(self) -> str:
+        """Convert LaTeX to text."""
+        text = LatexNodes2Text().latex_to_text(self.tex.strip())
+        # Remove running spaces inside the content
+        return re.sub(" +", " ", text)

--- a/src/documenteer/storage/localtemplates.py
+++ b/src/documenteer/storage/localtemplates.py
@@ -1,0 +1,50 @@
+"""Interface to local Jinja templates for maintaining project repositories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import jinja2
+
+__all__ = ["LocalProjectTemplates"]
+
+
+class LocalProjectTemplates:
+    """Interface to local Jinja templates for project repositories."""
+
+    def __init__(self) -> None:
+        self._dir = Path(__file__).parent / "localtemplates"
+
+    def get_template(self, name: str) -> jinja2.Template:
+        """Get a template by name.
+
+        Parameters
+        ----------
+        name
+            The name of the template.
+
+        Returns
+        -------
+        `jinja2.Template`
+            The template object.
+        """
+        env = jinja2.Environment(loader=jinja2.FileSystemLoader(self._dir))
+        return env.get_template(name)
+
+    def write(self, *, name: str, path: Path, context: dict[str, Any]) -> None:
+        """Write a template to a file.
+
+        Parameters
+        ----------
+        name
+            The name of the template.
+        path
+            The path to write to.
+        context
+            The template context.
+        """
+        template = self.get_template(name)
+        output_dir = path.parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(template.render(**context) + "\n")

--- a/src/documenteer/storage/localtemplates/technote/Makefile
+++ b/src/documenteer/storage/localtemplates/technote/Makefile
@@ -1,0 +1,18 @@
+.PHONY:
+init:
+	pip install tox pre-commit
+	pre-commit install
+
+.PHONY:
+html:
+	tox run -e html
+
+.PHONY:
+lint:
+	tox run -e lint,link-check
+
+.PHONY:
+clean:
+	rm -rf _build
+	rm -rf .technote
+	rm -rf .tox

--- a/src/documenteer/storage/localtemplates/technote/Makefile
+++ b/src/documenteer/storage/localtemplates/technote/Makefile
@@ -12,6 +12,14 @@ lint:
 	tox run -e lint,link-check
 
 .PHONY:
+add-author:
+	tox run -e add-author
+
+.PHONY:
+sync-authors:
+	tox run -e sync-authors
+
+.PHONY:
 clean:
 	rm -rf _build
 	rm -rf .technote

--- a/src/documenteer/storage/localtemplates/technote/README.rst
+++ b/src/documenteer/storage/localtemplates/technote/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/{{ cookiecutter.repo_name|replace("-", "--") }}-lsst.io-brightgreen.svg
+   :target: {{ cookiecutter.url }}
+.. image:: https://github.com/{{ cookiecutter.github_namespace }}/workflows/CI/badge.svg
+   :target: https://github.com/{{ cookiecutter.github_namespace }}/actions/
+
+{{ "#" * cookiecutter.title|length }}
+{{ cookiecutter.title }}
+{{ "#" * cookiecutter.title|length }}
+
+{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}
+{{ "=" * (cookiecutter.series|length + cookiecutter.serial_number|length + 1) }}
+
+{{ cookiecutter.description }}
+
+**Links:**
+
+- Publication URL: {{ cookiecutter.url }}
+- Alternative editions: {{ cookiecutter.url }}/v
+- GitHub repository: https://github.com/{{ cookiecutter.github_namespace }}
+- Build system: https://github.com/{{ cookiecutter.github_namespace }}/actions/
+
+Build this technical note
+=========================
+
+You can clone this repository and build the technote locally if your system has Python 3.11 or later:
+
+.. code-block:: bash
+
+   git clone https://github.com/{{ cookiecutter.github_namespace }}
+   cd {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+   make init
+   make html
+
+Repeat the ``make html`` command to rebuild the technote after making changes.
+If you need to delete any intermediate files for a clean build, run ``make clean``.
+
+The built technote is located at ``_build/html/index.html``.
+
+Publishing changes to the web
+=============================
+
+This technote is published to {{ cookiecutter.url }} whenever you push changes to the ``main`` branch on GitHub.
+When you push changes to a another branch, a preview of the technote is published to {{ cookiecutter.url }}/v.
+
+Editing this technical note
+===========================
+
+The main content of this technote is in ``index.rst`` (a reStructuredText file).
+Metadata and configuration is in the ``technote.toml`` file.
+For guidance on creating content and information about specifying metadata and configuration, see the Documenteer documentation: https://documenteer.lsst.io/technotes.

--- a/src/documenteer/storage/localtemplates/technote/ci.yaml
+++ b/src/documenteer/storage/localtemplates/technote/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+
+'on': [push, pull_request, workflow_dispatch]
+
+jobs:
+  call-workflow:
+    uses: lsst-sqre/rubin-sphinx-technote-workflows/.github/workflows/ci.yaml@v1
+    with:
+      handle: {{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}
+    secrets:
+      ltd_username: {% raw %}${{ secrets.LTD_USERNAME }}{% endraw %}
+      ltd_password: {% raw %}${{ secrets.LTD_PASSWORD }}{% endraw %}

--- a/src/documenteer/storage/localtemplates/technote/conf.py
+++ b/src/documenteer/storage/localtemplates/technote/conf.py
@@ -1,0 +1,4 @@
+# See the Documenteer docs for how to customize conf.py:
+# https://documenteer.lsst.io/technotes/
+
+from documenteer.conf.technote import *  # noqa F401 F403

--- a/src/documenteer/storage/localtemplates/technote/dependabot.yml
+++ b/src/documenteer/storage/localtemplates/technote/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/src/documenteer/storage/localtemplates/technote/gitignore
+++ b/src/documenteer/storage/localtemplates/technote/gitignore
@@ -1,0 +1,5 @@
+_build/
+.technote/
+.tox/
+venv/
+.venv/

--- a/src/documenteer/storage/localtemplates/technote/pre-commit-config.yaml
+++ b/src/documenteer/storage/localtemplates/technote/pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      # - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-toml

--- a/src/documenteer/storage/localtemplates/technote/requirements.txt
+++ b/src/documenteer/storage/localtemplates/technote/requirements.txt
@@ -1,0 +1,1 @@
+documenteer[technote]>=1.0,<2.0

--- a/src/documenteer/storage/localtemplates/technote/tox.ini
+++ b/src/documenteer/storage/localtemplates/technote/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+environments = html
+isolated_build = True
+
+[testenv]
+skip_install = true
+deps =
+    -rrequirements.txt
+
+[testenv:html]
+commands =
+   sphinx-build --keep-going -n -W -T -b html -d _build/doctrees . _build/html
+
+[testenv:linkcheck]
+commands =
+   sphinx-build --keep-going -n -W -T -b linkcheck -d _build/doctrees . _build/linkcheck
+
+[testenv:lint]
+commands =
+   pre-commit run --all-files

--- a/src/documenteer/storage/localtemplates/technote/tox.ini
+++ b/src/documenteer/storage/localtemplates/technote/tox.ini
@@ -18,3 +18,11 @@ commands =
 [testenv:lint]
 commands =
    pre-commit run --all-files
+
+[testenv:add-author]
+commands =
+    documenteer technote add-author
+
+[testenv:sync-authors]
+commands =
+    documenteer technote sync-authors

--- a/src/documenteer/storage/technotetoml.py
+++ b/src/documenteer/storage/technotetoml.py
@@ -86,7 +86,10 @@ class TechnoteTomlFile:
         # if "authors" in self._doc["technote"].keys():
 
         for existing_author in self.authors_aot:
-            if existing_author["internal_id"] == author.author_id:
+            if (
+                "internal_id" in existing_author
+                and existing_author["internal_id"] == author.author_id
+            ):
                 author_exists = True
                 # Write over the existing author
                 self._update_author(existing_author, author)

--- a/src/documenteer/storage/technotetoml.py
+++ b/src/documenteer/storage/technotetoml.py
@@ -105,8 +105,12 @@ class TechnoteTomlFile:
         self, table: tomlkit.items.Table, author: AuthorInfo
     ) -> None:
         """Update a toml author table with the AuthorInfo data."""
-        table["given"] = author.given_name
-        table["family"] = author.family_name
+        # TODO properly add the table for the authors's name.
+        name_table = tomlkit.inline_table()
+        # name_table = tomlkit.out_of_order_dict()
+        name_table["given"] = author.given_name
+        name_table["family"] = author.family_name
+        table["name"] = name_table
         table["internal_id"] = author.author_id
         if author.orcid is not None:
             table["orcid"] = author.orcid

--- a/src/documenteer/storage/technotetoml.py
+++ b/src/documenteer/storage/technotetoml.py
@@ -1,0 +1,132 @@
+"""Interface to a technote.toml file for a technote."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Self, cast
+
+import tomlkit
+
+from .authordb import AffiliationInfo, AuthorInfo
+
+__all__ = ["TechnoteTomlFile"]
+
+
+class TechnoteTomlFile:
+    """An editable technote.toml file.
+
+    To create this class from a file `~pathlib.Path`, using the `open` class
+    method.
+
+    Parameters
+    ----------
+    content
+        The text content of the technote.toml file.
+    """
+
+    def __init__(self, content: str) -> None:
+        self._doc = tomlkit.parse(content)
+
+    @property
+    def doc(self) -> tomlkit.TOMLDocument:
+        """The editable tomlkit document."""
+        return self._doc
+
+    @classmethod
+    def open(cls, path: Path) -> Self:
+        """Open a technote.toml file from the given path.
+
+        Parameters
+        ----------
+        path
+            The path to the technote.toml file.
+
+        Returns
+        -------
+        `TechnoteTomlFile`
+            The technote.toml file object.
+        """
+        text = path.read_text()
+        return cls(text)
+
+    def save(self, path: Path) -> None:
+        """Write the technote.toml file to the given path."""
+        path.write_text(tomlkit.dumps(self._doc))
+
+    @property
+    def technote_table(self) -> tomlkit.items.Table:
+        """The technote table."""
+        if "technote" not in self._doc.keys():
+            self._doc["technote"] = tomlkit.table()
+        return cast(tomlkit.items.Table, self._doc["technote"])
+
+    @property
+    def authors_aot(self) -> tomlkit.items.AoT:
+        """The authors array of tables."""
+        if "authors" not in self.technote_table.keys():
+            self.technote_table["authors"] = tomlkit.aot()
+        return cast(tomlkit.items.AoT, self.technote_table["authors"])
+
+    @property
+    def author_ids(self) -> list[str]:
+        """A list of author IDs (keys in authordb.yaml).
+
+        Authors without an ``internal_id`` are not included.
+        """
+        if "authors" not in self.technote_table.keys():
+            return []
+        return [
+            a["internal_id"] for a in self.authors_aot if "internal_id" in a
+        ]
+
+    def upsert_author(self, author: AuthorInfo) -> None:
+        """Append an author to the technote.toml file, or update in place."""
+        # Check if the author already exists
+        author_exists = False
+        # if "authors" in self._doc["technote"].keys():
+
+        for existing_author in self.authors_aot:
+            if existing_author["internal_id"] == author.author_id:
+                author_exists = True
+                # Write over the existing author
+                self._update_author(existing_author, author)
+                break
+
+        if not author_exists:
+            # Append a new author
+            t = tomlkit.table()
+            self._update_author(t, author)
+            self.authors_aot.append(t)
+
+    def _update_author(
+        self, table: tomlkit.items.Table, author: AuthorInfo
+    ) -> None:
+        """Update a toml author table with the AuthorInfo data."""
+        table["given"] = author.given_name
+        table["family"] = author.family_name
+        table["internal_id"] = author.author_id
+        table["orcid"] = author.orcid
+
+        if "affiliations" not in table:
+            table.add("affiliations", tomlkit.aot())
+        affiliations_aot = cast(tomlkit.items.AoT, table["affiliations"])
+        existing_affiliation_ids = [a["internal_id"] for a in affiliations_aot]
+        for affiliation in author.affiliations:
+            if affiliation.id not in existing_affiliation_ids:
+                # Add a new affiliation
+                new_affiliation_table = tomlkit.table()
+                self._update_affiliation(new_affiliation_table, affiliation)
+                affiliations_aot.append(new_affiliation_table)
+            else:
+                # Update existing affiliation
+                for t in affiliations_aot:
+                    if t["internal_id"] == affiliation.id:
+                        self._update_affiliation(t, affiliation)
+                        break
+
+    def _update_affiliation(
+        self, t: tomlkit.items.Table, affiliation_info: AffiliationInfo
+    ) -> None:
+        t["name"] = affiliation_info.name
+        t["internal_id"] = affiliation_info.id
+        t["address"] = affiliation_info.address

--- a/src/documenteer/storage/technotetoml.py
+++ b/src/documenteer/storage/technotetoml.py
@@ -108,7 +108,8 @@ class TechnoteTomlFile:
         table["given"] = author.given_name
         table["family"] = author.family_name
         table["internal_id"] = author.author_id
-        table["orcid"] = author.orcid
+        if author.orcid is not None:
+            table["orcid"] = author.orcid
 
         if "affiliations" not in table:
             table.add("affiliations", tomlkit.aot())

--- a/tests/data/authordb.yaml
+++ b/tests/data/authordb.yaml
@@ -1,0 +1,4112 @@
+affiliations:
+  AAS: American Astronomical Society
+  Adler: The Adler Planetarium, 1300 South Lakeshore Ave., Chicago, IL 60605, USA
+  ALMA: Atacama Large Millimeter/submillimeter Array, San Pedro de Atacama, Antofagasta, Chile
+  AMNH: Department of Astrophysics, American Museum of Natural History, New York,
+    NY 10028, USA
+  ASTRON: ASTRON, Oude Hoogeveensedijk 4, 7991\,PD, Dwingeloo, The Netherlands
+  BNL: Brookhaven National Laboratory, Upton, NY 11973, USA
+  Belgrade-AO: Astronomical Observatory, Volgina 7, P.O.\ Box 74, 11060 Belgrade,
+    Serbia
+  Belgrade-Uni: Faculty of Mathematics, Department of Astronomy, University of Belgrade,
+    Studentski trg 16 Belgrade, Serbia
+  Belgrade-CS: Department of Informatics and Computer Science, Faculty of Mathematics,
+    University of Belgrade, Studentski trg 16, 11000 Belgrade, Serbia
+  Belldex: Belldex IT Consulting, Tucson, AZ 85742, USA
+  Berkeley-Astro: Astronomy Department,  University of California, 601 Campbell Hall,
+    Berkeley, CA 94720, USA
+  Berkeley-LBNL: Lawrence Berkeley National Laboratory, 1 Cyclotron Road, Berkeley,
+    CA 94720, USA
+  Berkeley-Space: Space Sciences Lab, University of California, 7 Gauss Way, Berkeley,
+    CA 94720-7450, USA
+  Burwood: Burwood Group, 125 South Wacker Drive Suite 2950, Chicago, IL 60606, USA
+  CADC: Canadian Astronomy Data Centre, 5071 West Saanich Road, Victoria, British Columbia V9E 2E7, Canada
+  Cardiff: School of Physics and Astronomy, Cardiff University, The Parade, Cardiff, CF24 3AA, UK
+  CCA: Center for Computational Astrophysics, Flatiron Institute, 162 Fifth Ave, New York, NY,
+    10010, USA
+  CMU: McWilliams Center for Cosmology, Department of Physics, Carnegie Mellon University,
+    Pittsburgh, PA 15213, USA
+  CNRS: Centre national de la recherche scientifique, 3 Rue Michel Ange, 75016 Paris, France
+  Cochin: The Cochin College, Kerala, India 682002
+  CNCT: Consejo Nacional de Ciencia y Tecnolog\'ia, Av. Insurgentes Sur 1582.
+    Colonia Cr\'edito Constructor, Del. Benito   Ju\'arez C.P. 03940, M\'exico D.F. M\'exico
+  COOK: Cook Astronomical Consulting, 220 Duxbury Ct., San Ramon, CA 94583, USA
+  CONICET: Consejo Nacional de Investigaciones Cient\'{i}ficas y T\'{e}cnicas, Argentina
+  Columbia: Columbia University, 533 W. 218th St. New York, NY 10034
+  CPPM: Aix Marseille Univ, CNRS/IN2P3, CPPM, Marseille, France
+  CTIO: Cerro Tololo Inter-American Observatory, La Serena, Chile
+  CUMBRES: Las Cumbres Observatory, 6740 Cortona Dr., Suite 102, Goleta, CA
+    93117, USA
+  CUNY: City University of New York
+  CUNYAMNH: City University of New York, American Museum of Natural History
+  CUNYCT: City University of New York, New York City College of Technology
+  CUNYBM: Department of Science, CUNY Borough of Manhattan Community College, 199 Chambers
+    Street, New York, NY 10007, USA
+  CUNYL: Department of Physics and Astronomy, Lehman College, City University of New York,
+    NY 10468, USA
+  CUNY-Grad: The Graduate Center of the City University of New York, 365 Fifth Avenue,
+    New York, NY 10016, USA
+  CUNY-Hunter: City University of New York,  Hunter College, Hunter North Building, 695 Park Ave.,
+    New York, NY 10065, USA
+  Caltech-Astro: Astronomy Department, California Institute of Technology, 1200 East
+    California Blvd., Pasadena CA 91125, USA
+  Caltech: Division of Physics, Mathematics and Astronomy, California Institute of Technology,
+    Pasadena, CA 91125, USA
+  Caltech-CDDD: Center for Data Driven Discovery, California Institute of Technology,
+    Pasadena, CA 91125, USA
+  ChUniv: Astronomical Institute, Charles University, Praha, Czech Republic
+  Chicago: Department of Astronomy and Astrophysics, University of Chicago, 5640 South
+    Ellis Avenue, Chicago, IL 60637, USA
+  CIERA: Center for Interdisciplinary Exploration and Research in Astrophysics (CIERA) and
+    Department of Physics and Astronomy, Northwestern University, 1800 Sherman Road,
+    Evanston, IL 60201, USA
+  Clermont-LPC: Universit\'e Clermont Auvergne, CNRS$/$IN2P3, Laboratoire de Physique de Clermont,
+    F-63000 Clermont-Ferrand, France
+  DACC: DACC New Mexico State University, Central Campus, Las Cruces, New Mexico, USA
+  DARK: DARK, Niels Bohr Institute, University of Copenhagen, Denmark
+  Delaware-PhyAst: Department of Physics and Astronomy, University of Delaware, Newark,
+    DE 19716-2570, USA
+  Delaware-Policy: Joseph R.\ Biden, Jr.,  School of Public Policy and Administration,
+    University of Delaware, Newark, DE 19717 USA
+  Delaware-DataSci: Data Science Institute, University of Delaware, Newark, DE 19717 USA
+  DGPS: Division of Geological and Planetary Sciences, California Institute of Technology,
+    Pasadena, CA 91125, USA
+  DIRAC: Institute for Data-intensive Research in Astrophysics and Cosmology, University of Washington,
+    Seattle, WA
+  DOE: Office of Science, U.S. Department of Energy, 1000 Independence Ave.,
+    SW Washington, DC 20585, USA
+  Drexel: Drexel University, 3141 Chestnut St, Philadelphia, PA 19104
+  Duke: Department of Physics, Duke University, Durham, NC 27708, USA
+  Edinburgh: University of Edinburgh, Old College, South Bridge, Edinburgh EH8 9YL
+  EdinburghIA: Institute for Astronomy, University of Edinburgh,  Royal Observatory, Blackford Hill, Edinburgh EH9 3HJ, UK
+  EPFL: Institute of Physics, Laboratory of Astrophysics, \'{E}cole Polytechnique
+    Fed\`{e}rale de Lausanne (EPFL), Observatoire de Sauverny, 1290 Versoix, Switzerland
+  ESO: European Southern Observatory, Karl-Schwarzschild-Strasse 2, 85748 Garching bei München, Germany
+  FacebookNE: Facebook,  14734 Friend Plaza, Springfield, NE 68059, USA
+  Fermilab: Fermi National Accelerator Laboratory, P. O. Box 500, Batavia, IL 60510, USA
+  FSU: Florida State University, Tallahassee, FL 32306
+  GCCL: German Centre for Cosmological Lensing, Astronomisches Institut,
+    Ruhr-Universit\"{a}t Bochum, Universit\"{a}tsstr. 150, 44801 Bochum, Germany
+  GeorgiaState: Georgia State University, Atlanta, GA 30302, USA
+  GMTO: Giant Magellan Telescope Organization (GMTO), 465 N.\ Halstead Street, Suite
+    250, Pasadena, CA 91107, USA
+  GMU: School of Physics, Astronomy and Computational Sciences, George Mason University,
+    4400 University Drive, Fairfax, VA 22030, USA
+  GeminiN: Gemini Observatory, Northern Operations Center, 670 North A'ohoku Place,
+    Hilo, HI 96720, USA
+  Goddard: Astrophysics Science Division, NASA Goddard Space Flight Center, Mail Code 661, Greenbelt, MD 20771, US
+  Google: Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA
+  Grenoble-LPSC: Laboratoire de Physique Subatomique et de Cosmologie, Universit\'{e}
+    Grenoble-Alpes, CNRS/IN2P3, 53 av.\ des Martyrs, 38026 Grenoble cedex, France
+  Hamburg: Hamburger Sternwarte, Universitat Hamburg, Gojenbergsweg 112,
+    21029 Hamburg, Germany
+  Harvard-Astro: Department of Astronomy, Center for Astrophysics, Harvard University,
+    60 Garden St., Cambridge, MA 02138, USA
+  Harvard-CfA: Center for Astrophysics, Harvard \& Smithsonian, 60 Garden Street, Cambridge, MA 02138
+  Harvard-Physics: Department of Physics, Harvard University, 17 Oxford St., Cambridge
+    MA 02138, USA
+  Haverford: Department of Astronomy, Haverford College, 370 Lancaster Avenue, Haverford,
+    PA 19041, USA
+  Heidelberg: Zentrum f{\"u}r Astronomie der Universit{\"a}t Heidelberg, Astronomisches Rechen-Institut,
+    M{\"o}nchhofstr. 12-14, 69120 Heidelberg, Germany
+  Herts: Centre for Astrophysics Research, University of Hertfordshire, Hatfield, Hertfordshire, AL10 9AB, UK
+  IAFE: Instituto de Astronom\'ia y F\'isica del Espacio (IAFE), Av. Inte. G\"uiraldes 2620, C1428ZAA, Buenos Aires, Argentina
+  IPAC: IPAC, California Institute of Technology, MS 100-22, Pasadena, CA 91125, USA
+  IRAM: Instituto de Radioastronom\'ia Milim\'{e}trica, Av.\ Divina Pastora 7, N\'{u}cleo
+    Central, E-18012 Granada, Spain
+  Illinois: University of Illinois, Physics and Astronomy Departments, 1110 W.\ Green
+    St., Urbana, IL  61801, USA
+  Illinois-astro: University of Illinois, Department of Astronomy, 1110 W.\ Green
+    St., Urbana, IL  61801, USA
+  INAF-Rome: Istituto Nazionale di Astrofisica, Viale del Parco Mellini 84, 00136 Rome, Italy
+  INAF-Palermo: INAF - Osservatorio Astronomico di Palermo, Piazza del Parlamento 1 90134,
+    Palermo, Italy
+  IUPUI: IUPUI, 535 W. Michigan Street, IT 400, Indianapolis, IN, USA
+  JHU: Department of Physics and Astronomy, The John Hopkins University, 3701 San
+    Martin Drive, Baltimore, MD 21218, USA
+  JPL: Jet Propulsion Laboratory, California Institute of Technology, Pasadena, CA
+    91109, USA
+  JPMORGAN: J.P. Morgan, New York, NY, USA
+  JSI: Joint Space-Science Institute, University of Maryland, College Park, MD 20742, USA
+  KECK: W. M. Keck Observatory, 65-1120 Mamalahoa Hwy.  Kamuela, HI 96743, USA
+  KIPAC: Kavli Institute for Particle Astrophysics and Cosmology, SLAC
+  KLOA: Key Laboratory of Optical Astronomy, National Astronomical Observatories,
+    Chinese Academy of Sciences, 20A Datun Road, Chaoyang District, Beijing 100012,
+    People's Republic of China
+  LAPP: Universit\'{e} Grenoble-Alpes, Universit\'{e} Savoie Mont Blanc, CNRS/IN2P3
+    Laboratoire d'Annecy-le-Vieux de Physique des Particules, 9 Chemin de Bellevue
+    -- BP 110, F-74940 Annecy-le-Vieux Cedex, France
+  Lieden: Leiden Observatory, Leiden University, Postbus 9513, 2300 RA, Leiden, The Netherlands
+  Liege: Institut d'Astrophysique et de G\'{e}ophysique, Universit\'{e} de Li\`{e}ge,
+    All\'{e}e du 6 Ao\^{u}t 19c, 4000 Li\`{e}ge, Belgium
+  LINEA: Laborat\'{o}rio Interinstitucional de e-Astronomia, Rua General Jos\'e Cristino, 77,
+    Rio de Janeiro, RJ, 20921-400, Brazil
+  LLNL: Lawrence Livermore National Laboratory, 7000 East Avenue, Livermore, CA 94550,
+    USA
+  LOC: Library of Congress, 101 Independence Ave.\ SE, Washington, DC 20540, USA
+  PSI: Planetary Science Institute, 1700 East Fort Lowell Road, Suite 106, Tucson, AZ 85719, USA
+  LUPM: Laboratoire Univers et Particules de Montpellier (LUPM), Universit\'{e} de
+    Montpellier, CNRS/IN2P3, Place Eug\`{e}ne Bataillon, F-34095 Montpellier, France
+  Longhorn: Longhorn Industries, Ellensburg, WA 98926, USA
+  Lowell: 1400 W.\ Mars Hill Rd., Lowell Observatory, Flagstaff, AZ 86001, USA
+  LSSTC: The LSST Corporation
+  Lyon-CC-IN2P3: CNRS, CC-IN2P3, 21 avenue Pierre de Coubertin, CS70202, F-69627 Villeurbanne
+    cedex, France
+  Lyon-LMA-IN2P3: Laboratoire des Materiaux Avances (LMA), CNRS/IN2P3, Universit\'{e}
+    de Lyon, F-69622 Villeurbanne, Lyon, France
+  Maryland: University of Maryland, College Park, MD 20742
+  Maryland-astro: Department of Astronomy, University of Maryland, College Park, MD 20742, USA
+  MMTO: MMT Observatory, 1540 E. Second Street, University of Arizona, Tucson, AZ 85721-0064, USA
+  NAOChina: National Astronomical Observatories, Chinese Academy of Sciences, A20
+    Datun Rd, Chaoyang District, Beijing 100012, People's Republic of China
+  NASA: National Aeronautics and Space Administration, Goddard Space Flight Center, Greenbelt, Maryland, USA
+  NAU: Department of Astronomy and Planetary Science, Northern Arizona University, P.O.\ Box
+    6010, Flagstaff, AZ 86011, USA
+  NCNRP: National Centre of Nuclear Research, Andrzeja So\l{}tana 7, 05-400 Otwock, Poland
+  NCSA: NCSA, University of Illinois at Urbana-Champaign, 1205 W.\ Clark St., Urbana,
+    IL 61801, USA
+  NOIRLab: NSF's National Optical-Infrared Astronomy Research Laboratory, 950 N.\ Cherry Ave., Tucson, AZ 85719, USA
+  NovaGorica: Center for Astrophysics and Cosmology, University of Nova Gorica, Vipavska 13
+    5000 Nova Gorica, Slovenia
+  NRAO: National Radio Astronomy Observstory, 520 Edgemont Road, Charlottesville, VA 22903, USA
+  NRC: National Research Council Canada, 5071 West Saanich Road, Victoria, Canada
+  NSF: National Science Foundation, 2415 Eisenhower Avenue, Alexandria, Virginia 22314, USA
+  NSO: National Solar Observatory, 3665 Discovery Drive, Boulder, CO 80303, USA
+  NYU: New York University, New York,
+  NYU-CCPP: Center for Cosmology \& Particle Physics, New York University,
+    726 Broadway, New York, 10003, USA
+  NYU-CUSP: Center for Urban Science \& Progress, New York University, Brooklyn, NY
+    11021, USA
+  OKC: Oskar Klein Centre, Department of Physics, Stockholm University, SE 106 91
+    Stockholm, Sweden
+  OSU: Center for Cosmology and Astro-Particle Physics, The Ohio State University,
+    Columbus, OH 43210, USA
+  Olympic: Olympic College, 1600 Chester Ave., Bremerton, WA 98337-1699, USA
+  Oxford: Department of Physics, University of Oxford, Denys Wilkinson Building, Keble
+    Road, Oxford, OX1 3RH, UK
+  PSU: Department of Astronomy and Astrophysics, The Pennsylvania State University,
+    525 Davey Lab, University Park, PA 16802, USA
+  PSUCDS: Institute for Computational \& Data Sciences, The Pennsylvania State University, University Park, PA 16802, USA
+  PSUGC: Institute for Gravitation and the Cosmos, The Pennsylvania State University, University Park, PA 16802, USA
+  Paris-APC: AstroParticule et Cosmologie, Universit\'{e} Paris Diderot, CNRS/IN2P3,
+    CEA/lrfu, Observatoire de Paris, Sorbonne Paris Cit\'{e}, 10, rue Alice Domon
+    et L\'{e}onie Duquet, Paris Cedex 13, France
+  Paris-Diderot: Universit\'{e} Paris Diderot, Sorbonne Paris Cit\'{e}, F-75013 Paris,
+    France
+  Paris-LAL: Laboratoire de l'Acc\'{e}l\'{e}rateur Lin\'{e}aire, CNRS/IN2P3, Universit\'{e}
+    de Paris-Sud, B.P.\ 34, 91898 Orsay Cedex, France
+  Paris-LPNHE: Laboratoire de Physique Nucl\'{e}aire et des Hautes Energies, Universit\'{e}
+    Pierre et Marie Curie, Universit\'{e} Paris Diderot, CNRS/IN2P3, 4 place Jussieu,
+    75005 Paris, France
+  Paris-UPMC: Sorbonne Universit\'{e}s, UPMC Univ Paris 06, UMR 7585, LPNHE, F-75005,
+    Paris, France
+  Peay: Austin Peay State University, Clarksville, TN 37044, USA
+  Pitts: Department of Physics and Astronomy, University of Pittsburgh, 3941 O'Hara
+    Street, Pittsburgh, PA 15260, USA
+  Praha-ASCR: Institute of Physics, Academy of Sciences of the Czech Republic, Na
+    Slovance 2, 182 21 Praha 8, Czech Republic
+  Princeton-Astro: Department of Astrophysical Sciences, Princeton University, Princeton,
+    NJ 08544, USA
+  Purdue-Astro: Department of Physics and Astronomy, Purdue University, 525 Northwestern
+    Ave., West Lafayette, IN  47907, USA
+  Radboud-Astro: Department of Astrophysics/IMAPP, Radboud University Nijmegen, P.O.\
+    Box 9010, 6500 GL Nijmegen, The Netherlands
+  Rider: Department of Chemistry, Biochemistry, and Physics, Rider University, Lawrenceville,
+    NJ 08648, USA
+  RubinObs: Rubin Observatory Project Office, 950 N.\ Cherry Ave., Tucson, AZ  85719, USA
+  RubinObsC: Vera C. Rubin Observatory, Casilla 603 Colina El Pino, La Serena, Chile
+  Rutgers: Department of Physics and Astronomy, Rutgers University, 136 Frelinghuysen
+    Rd., Piscataway, NJ 08854, USA
+  Saclay: Universit\'e Paris-Saclay, Universit\'e Paris Cit\'e, CEA, CNRS, AIM, 91191, Gif-sur-Yvette, France
+  Santiago-dept: Departamento de Ciencias Fisicas, Universidad Andres Bello Fernandez
+    Concha 700, Las Condes, Santiago, Chile
+  Santiago-Millenium: Millennium Institute of Astrophysics, Nuncio Monse{\~{n}}or S{\'{o}}tero
+    Sanz 100, Of 104, Providencia, Santiago, Chile
+  SAO: Smithsonian Astrophysical Observatory, 60 Garden St., Cambridge MA 02138, USA
+  SETI: SETI Institute, 339 Bernardo Avenue, Suite 200, Mountain View, CA 94043, USA
+  SLAC: SLAC National Accelerator Laboratory,  2575 Sand Hill Rd., Menlo Park, CA
+    94025, USA
+  SLAC-Kavli: Kavli Institute for Particle Astrophysics and Cosmology, SLAC National
+    Accelerator Laboratory, Stanford University, Stanford, CA 94025, USA
+  Southampton: University of Southampton, Hartley Library B12, University Rd,
+    Highfield, Southampton SO17 1BJ, United Kingdom
+  STScI: Space Telescope Science Institute, 3700 San Martin Drive, Baltimore, MD 21218,
+    USA
+  SVC: Saint Vincent College, Department of Physics, 300 Fraser Purchase Road, Latrobe,
+    PA 15650, USA
+  TACC: Texas Advanced Computing Center, The University of Texas at Austin, USA.
+  TAMU-inst: George P.~and Cynthia Woods Mitchell Institute for Fundamental Physics and Astronomy,
+    Texas A\&M University, College Station, TX 77843, USA
+  TAMU: Department of Physics and Astronomy, Texas A\&M University, College Station, TX 77843, USA
+  TMT: TMT International Observatory
+  TTU: Department of Physics and Astronomy, Texas Tech University, Lubbock, TX 79409, USA
+  TTU-media: College of Media and Communication, Texas Tech University, Lubbock, TX 79409, USA
+  UA: University of Arizona, Tucson, AZ 85721, USA
+  UA-CompSci: Department of Computer Science, The University of Arizona, 1040 E.\
+    4th St., Tucson, AZ 85719, USA
+  UAM: Universidad Aut\'onoma de Madrid, Madrid, Madrid, ES
+  UA-Astro: University of Arizona, Department of Astronomy and Steward Observatory, 933 N Cherry Ave, Tucson, AZ 85721, USA
+  UA-Physics: Department of Physics, University of Arizona, 1118 E.\ Fourth Street,
+    Tucson, AZ 85721, USA
+  UA-Steward: Steward Observatory, The University of Arizona, 933 N.\ Cherry Ave.,
+    Tucson, AZ 85721, USA
+  UCDavis: Physics Department, University of California, One Shields Avenue, Davis,
+    CA 95616, USA
+  UCIrvine-Astro: Department of Physics and Astronomy, University of California, 4129
+    Frederick Reines Hall, Irvine, CA 92697, USA
+  UCIrvine-CC: Center for Cosmology, University of California, Irvine, CA 92697, USA
+  UCL: University College London, Gower St, London WC1E 6BT, United Kingdom
+  UCO: UC Observatories, UC Santa Cruz, 1156 High Street, Santa Cruz, CA 95064
+  UCSB: University of California, Santa Barbara, CA 93106-9530, USA
+  UCSC: Santa Cruz Institute for Particle Physics and Physics Department, University
+    of California--Santa Cruz, 1156 High St., Santa Cruz, CA 95064, USA
+  UdG: Departamento de F\'isica, DCI, Campus Le\'on, Universidad de Guanajuato, 37150, Le\'on, Guanajuato, M\'exico
+  UniAndes: Universidad de los Andes, Cra 1 Num. 18A - 12 Bogot\'{a} - Colombia
+  UNAM: Universidad Nacional Aut\'{o}noma de M\'{e}xico
+  UNAM-physics: Departamento de F\'isica, Facultad de Ciencias, Universidad Nacional Aut\'onoma de M\'exico,
+    Ciudad Universitaria, CDMX, 04510, M\'exico
+  UNAM-astro: Instituto de Astronom\'ia sede Ensenada, Universidad Nacional Aut\'onoma de M\'exico, Km 107,
+    Carret. Tij.-Ens., Ensenada, 22060, BC, M\'exico
+  UNED: Dpt. of Artificial Intelligence, Universidad Nacional de Educaci\'{o}n a Distancia, Madrid, Madrid, ES
+  UPenn: Department of Physics \& Astronomy, University of Pennsylvania, 209 South
+    33rd Street, Philadelphia, PA 19104-6396, USA
+  URijeka: Faculty of Physics, University of Rijeka, Radmile Matej\v{c}i\'{c} 2, Rijeka, Croatia
+  Utah: Department of Physics and Astronomy, University of Utah, Salt Lake City, UT 84112, USA
+  UToronto: University of Toronto, 27 King's College Circle, Toronto, Ontario M5S 1A1 Canada
+  USNO: US Naval Observatory Flagstaff Station, 10391 Naval Observatory Road, Flagstaff,
+    AZ 86001, USA
+  UVa: Department of Astronomy, University of Virginia, Charlottesville, VA 22904,
+    USA
+  Vdb: Vanderbilt University, Nashville, Tennessee 37240
+  Washington: University of Washington, Dept.\ of Astronomy, Box 351580, Seattle,
+    WA 98195, USA
+  Washington-Dirac: Department of Astronomy and the DIRAC Institute, University of Washington,
+    3910 15th Avenue NE, Seattle, WA 98195, USA
+  WestWashington: Western Washington University, 516 High Street, Bellingham, WA 98225,
+    USA
+  WisconsinMadison: Department of Physics, University of Wisconsin-Madison, Madison,
+    WI 53706, USA
+  Yale: Astronomy Department, Yale University, New Haven, CT 06520, USA
+authors:
+  abelb:
+    affil:
+    - Olympic
+    altaffil: []
+    initials: Bob
+    name: Abel
+    orcid: null
+  accomazzia:
+    affil:
+    - Harvard-CfA
+    altaffil: []
+    initials: Alberto
+    name: Accomazzi
+    orcid: null
+  acostae:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Emily
+    name: Acosta
+    orcid: null
+  acquavivav:
+    affil:
+    - CCA
+    - CUNYCT
+    altaffil: []
+    initials: Viviana
+    name: Acquaviva
+    orcid: null
+  adaircl:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Christina L.
+    name: Adair
+    orcid: null
+  ahumadat:
+    affil:
+    - Maryland
+    altaffil: []
+    initials: Tomas
+    name: Ahumada
+    orcid: null
+  allberyr:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Russ
+    name: Allbery
+    orcid: null
+  allsmanr:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Robyn
+    name: Allsman
+    orcid: null
+  alonsod:
+    affil:
+    - Oxford
+    altaffil: []
+    initials: David
+    name: Alonso
+    orcid: null
+  alsayyady:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Yusra
+    name: AlSayyad
+    orcid: null
+  alvecs:
+    affil:
+    - UCL
+    altaffil: []
+    initials: Catarina S.
+    name: Alves
+    orcid: 0000-0002-6164-9044
+  andersonsf:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Scott F.
+    name: Anderson
+    orcid: null
+  andrewj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: John
+    name: Andrew
+    orcid: null
+  andreonii:
+    affil:
+    - JSI
+    - Maryland-astro
+    - Goddard
+    altaffil: []
+    initials: Igor
+    name: Andreoni
+    orcid: 0000-0002-8977-1498
+  andricmitrovicn:
+    affil:
+    - Belgrade-CS
+    altaffil: []
+    initials: Nikola
+    name: Andri\'{c} Mitrovi\'{c}
+    orcid: null
+  angeligz:
+    affil:
+    - GMTO
+    altaffil: []
+    initials: George Z.
+    name: Angeli
+    orcid: null
+  angeljrp:
+    affil:
+    - UA-Steward
+    altaffil: []
+    initials: James Roger P.
+    name: Angel
+    orcid: null
+  anguitat:
+    affil:
+    - Santiago-dept
+    - Santiago-Millenium
+    altaffil: []
+    initials: Timo
+    name: Anguita
+    orcid: 0000-0003-0930-5815
+  ansarir:
+    affil:
+    - Paris-LAL
+    altaffil: []
+    initials: Reza
+    name: Ansari
+    orcid: null
+  ansdellm:
+    affil:
+    - NASA
+    altaffil: []
+    initials: Megan
+    name: Ansdell
+    orcid: null
+  antilogusp:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Pierre
+    name: Antilogus
+    orcid: null
+  araujoc:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Constanza
+    name: Araujo
+    orcid: null
+  armstrongr:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Robert
+    name: Armstrong
+    orcid: null
+  arndtkt:
+    affil:
+    - Oxford
+    altaffil: []
+    initials: Kirk T.
+    name: Arndt
+    orcid: 0000-0002-6826-8340
+  astierp:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Pierre
+    name: Astier
+    orcid: null
+  aubourge:
+    affil:
+    - Paris-APC
+    altaffil: []
+    initials: \'{E}ric
+    name: Aubourg
+    orcid: null
+  auzan:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Nicole
+    name: Auza
+    orcid: null
+  axelrodts:
+    affil:
+    - UA-Steward
+    altaffil: []
+    initials: Tim S.
+    name: Axelrod
+    orcid: 0000-0002-5722-7199
+  banekc:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Christine
+    name: Banek
+    orcid: null
+  baileys:
+    affil:
+    - Berkeley-LBNL
+    altaffil: []
+    initials: Stephen
+    name: Bailey
+    orcid: null
+  barddj:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Deborah J.
+    name: Bard
+    orcid: 0000-0002-5162-5153
+  barraua:
+    affil:
+    - Grenoble-LPSC
+    altaffil: []
+    initials: Aurelian
+    name: Barrau
+    orcid: null
+  barrjd:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Jeff D.
+    name: Barr
+    orcid: null
+  barrettp:
+    affil:
+    - USNO
+    altaffil: []
+    initials: Paul
+    name: Barrett
+  bartlettjg:
+    affil:
+    - Paris-APC
+    altaffil: []
+    initials: James G.
+    name: Bartlett
+    orcid: null
+  bauerae:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Amanda E.
+    name: Bauer
+    orcid: 0000-0001-9037-6981
+  baumanbj:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Brian J.
+    name: Bauman
+    orcid: null
+  baumonts:
+    affil:
+    - Paris-UPMC
+    - Paris-LPNHE
+    altaffil: []
+    initials: Sylvain
+    name: Baumont
+    orcid: null
+  bechtole:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Ellen
+    name: Bechtol
+    orcid: null
+  bechtolk:
+    affil:
+    - RubinObs
+    - WisconsinMadison
+    altaffil: []
+    initials: Keith
+    name: Bechtol
+    orcid: null
+  beckerac:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Andrew C.
+    name: Becker
+    orcid: 0000-0001-6661-3043
+  beclaj:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Jacek
+    name: Becla
+    orcid: null
+  beldicac:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Cristina
+    name: Beldica
+    orcid: null
+  bellavias:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Steve
+    name: Bellavia
+    orcid: null
+  bellme:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Eric C.
+    name: Bellm
+    orcid: 0000-0001-8018-5348
+  berukoffs:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Steven
+    name: Berukoff
+    orcid: null
+  besth:
+    affil:
+    - CUNY-Grad
+    altaffil: []
+    initials: Henry J.
+    name: Best
+    orcid: null
+  biancofb:
+    affil:
+    - Delaware-PhyAst
+    - Delaware-Policy
+    - Delaware-DataSci
+    altaffil: []
+    initials: Federica B.
+    name: Bianco
+    orcid: 0000-0003-1953-8727
+  biswasr:
+    affil:
+    - OKC
+    altaffil: []
+    initials: Rahul
+    name: Biswas
+    orcid: null
+  blancg:
+    affil:
+    - Paris-LAL
+    - Paris-Diderot
+    altaffil: []
+    initials: Guillaume
+    name: Blanc
+    orcid: null
+  blandfordrd:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Roger D.
+    name: Blandford
+    orcid: null
+  blantonm:
+    affil:
+    - NYU-CCPP
+    altaffil: []
+    initials: Michael R.
+    name: Blanton
+    orcid: null
+  blazekj:
+    affil:
+    - OSU
+    - EPFL
+    altaffil: []
+    initials: Jonathan
+    name: Blazek
+    orcid: null
+  bloomjs:
+    affil:
+    - Berkeley-Astro
+    altaffil: []
+    initials: Josh S.
+    name: Bloom
+    orcid: null
+  blumrd:
+    affil:
+    - RubinObs
+    - NOIRLab
+    altaffil: []
+    initials: Robert D.
+    name: Blum
+    orcid: 0000-0002-8622-4237
+  bogartj:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Joanne
+    name: Bogart
+    orcid: null
+  boltona:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Adam
+    name: Bolton
+  bondtw:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Tim W.
+    name: Bond
+    orcid: null
+  bonitor:
+    affil:
+    - INAF-Palermo
+    altaffil: []
+    initials: Rosaria
+    name: Bonito
+    orcid: 0000-0001-9297-7748
+  boothmt:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Michael T.
+    name: Booth
+    orcid: null
+  borrillj:
+    affil:
+    - Berkeley-LBNL
+    altaffil: []
+    initials: Julian
+    name: Borrill
+    orcid: null
+  borglandaw:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Anders W.
+    name: Borgland
+    orcid: null
+  bornek:
+    affil:
+    - GMU
+    altaffil: []
+    initials: Kirk
+    name: Borne
+    orcid: null
+  boschjf:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: James F.
+    name: Bosch
+    orcid: 0000-0003-2759-5764
+  boutignyd:
+    affil:
+    - LAPP
+    altaffil: []
+    initials: Dominique
+    name: Boutigny
+    orcid: 0000-0003-4887-2150
+  brackettca:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Craig A.
+    name: Brackett
+    orcid: null
+  bradshawa:
+    affil:
+    - SLAC
+    - KIPAC
+    altaffil: []
+    initials: Andrew
+    name: Bradshaw
+    orcid: null
+  brandtwn:
+    affil:
+    - PSU
+    altaffil: []
+    initials: William Nielsen
+    name: Brandt
+    orcid: 0000-0002-0167-2453
+  breivikk:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Katelyn
+    name: Breivik
+    orcid: 0000-0001-5228-6598
+  brownme:
+    affil:
+    - DGPS
+    altaffil: []
+    initials: Michael E.
+    name: Brown
+    orcid: 0000-0002-8255-0545
+  bullockjs:
+    affil:
+    - UCIrvine-CC
+    altaffil: []
+    initials: James S.
+    name: Bullock
+    orcid: null
+  burchatp:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Patricia
+    name: Burchat
+    orcid: null
+  buttlerm:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Michelle
+    name: Buttler
+    orcid: null
+  burkec:
+    affil:
+    - Illinois-astro
+    altaffil: []
+    initials: Colin J.
+    name: Burke
+    orcid:
+  burkedl:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: David L.
+    name: Burke
+    orcid: 0000-0003-1866-1950
+  cagnolig:
+    affil:
+    - Lyon-LMA-IN2P3
+    altaffil: []
+    initials: Gianpietro
+    name: Cagnoli
+    orcid: null
+  calabresed:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Daniel
+    name: Calabrese
+    orcid: null
+  callahann:
+    affil:
+    - Oxford
+    altaffil: []
+    initials: Nick
+    name: Callahan
+    orcid: null
+  callahans:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Shawn
+    name: Callahan
+    orcid: null
+  callenal:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Alice L.
+    name: Callen
+    orcid: null
+  camposa:
+    affil:
+    - CMU
+    altaffil: []
+    initials: Andresa
+    name: Rodrigues de Campos
+    orcid: 0000-0002-5124-0771
+  cantiellom:
+    affil:
+    - CCA
+    - Princeton-Astro
+    altaffil: []
+    initials: Matteo
+    name: Cantiello
+    orcid:
+  caplarn:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Neven
+    name: Caplar
+    orcid: 0000-0002-3936-9628
+  carlinjl:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Jeffrey L.
+    name: Carlin
+    orcid: 0000-0002-3936-9628
+  carlsonel:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Erin L.
+    name: Carlson
+    orcid: null
+  chandlerc:
+    affil:
+    - NAU
+    altaffil: []
+    initials: Colin Orion
+    name: Chandler
+    orcid: 0000-0001-7335-1715
+  chanj:
+    affil:
+    - CUNY
+    altaffil: []
+    initials: James
+    name: Chan
+    orcid: null
+  chandrasekharans:
+    affil:
+    - UA-CompSci
+    altaffil: []
+    initials: Srinivasan
+    name: Chandrasekharan
+    orcid: null
+  charlesemersong:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Glenaver
+    name: Charles-Emerson
+    orcid: null
+  chesleys:
+    affil:
+    - JPL
+    altaffil: []
+    initials: Steve
+    name: Chesley
+    orcid: 0000-0003-3240-6497
+  cheuec:
+    affil:
+    - UA-Physics
+    altaffil: []
+    initials: Elliott C.
+    name: Cheu
+    orcid: null
+  chiangh:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Hsin-Fang
+    name: Chiang
+    orcid: 0000-0002-1181-1621
+  chiangj:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: James
+    name: Chiang
+    orcid: null
+  chirinoc:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Carol
+    name: Chirino
+    orcid: null
+  choiy:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Yumi
+    name: Choi
+    orcid: 0000-0003-1680-1884
+  chowd:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Derek
+    name: Chow
+    orcid: null
+  ciardidr:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: David R.
+    name: Ciardi
+    orcid: null
+  clavercf:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Charles F.
+    name: Claver
+    orcid: null
+  clementsaw:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Andy W.
+    name: Clements
+    orcid: null
+  cockrumjj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Joseph J.
+    name: Cockrum
+    orcid: null
+  cohentanugij:
+    affil:
+    - LUPM
+    altaffil: []
+    initials: Johann
+    name: Cohen-Tanugi
+    orcid: 0000-0001-9022-4232
+  colesr:
+    affil:
+    - OSU
+    altaffil: []
+    initials: Rebecca
+    name: Coles
+    orcid: 0000-0002-4774-9364
+  colleonif:
+    affil:
+    - RubinObsC
+    altaffil: []
+    initials: Franco
+    name: Colleoni
+    orcid: null
+  comorettog:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Gabriele
+    name: Comoretto
+    orcid: null
+  connollyaj:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Andrew J.
+    name: Connolly
+    orcid: 0000-0001-5576-8189
+  cookkh:
+    affil:
+    - COOK
+    altaffil: []
+    initials: Kem H.
+    name: Cook
+    orcid: null
+  cooraya:
+    affil:
+    - UCIrvine-CC
+    altaffil: []
+    initials: Asantha
+    name: Cooray
+    orcid: null
+  corliesl:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Lauren
+    name: Corlies
+    orcid: 0000-0002-0646-1540
+  corrall:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Luis
+    name: Corral
+    orcid: null
+  coveykr:
+    affil:
+    - WestWashington
+    altaffil: []
+    initials: Kevin R.
+    name: Covey
+    orcid: 0000-0001-6914-7797
+  cribbsc:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Chris
+    name: Cribbs
+    orcid: null
+  cruzk:
+    affil:
+    - CUNY-Hunter
+    altaffil: []
+    initials: Kelle
+    name: Cruz
+    orcid: null
+  cuiw:
+    affil:
+    - Purdue-Astro
+    altaffil: []
+    initials: Wei
+    name: Cui
+    orcid: 0000-0002-6324-5772
+  cutrir:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Roc
+    name: Cutri
+    orcid: 0000-0002-0077-2305
+  dacostal:
+    affil:
+    - LINEA
+    altaffil: []
+    initials: Luiz Nicolaci
+    name: da Costa
+    orcid: null
+  dalcantonj:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Julianne
+    name: Dalcanton
+    orcid: null
+  danielis:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Shany
+    name: Danieli
+    orcid: 0000-0002-1841-2252
+  danielsf:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Scott F.
+    name: Daniel
+    orcid: null
+  daruichf:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Felipe
+    name: Daruich
+    orcid: null
+  daubardg:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Guillaume
+    name: Daubard
+    orcid: null
+  dauesg:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Greg
+    name: Daues
+    orcid: null
+  davenportj:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: James R. A.
+    name: Davenport
+    orcid: 0000-0002-0637-835X
+  dawsonw:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: William
+    name: Dawson
+    orcid: 0000-0003-0248-6123
+  delgadof:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Francisco
+    name: Delgado
+    orcid: null
+  dellapennaa:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Alfred
+    name: Dellapenna
+    orcid: null
+  dennihye:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Erik
+    name: Dennihy
+    orcid: null
+  depeysterr:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Robert
+    name: de Peyster
+    orcid: null
+  desaiv:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Vandana
+    name: Desai
+    orcid: null
+  devalborrom:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Miguel
+    name: de Val-Borro
+    orcid: 0000-0002-0455-9384
+  digelsw:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Seth W.
+    name: Digel
+    orcid: null
+  dohertyp:
+    affil:
+    - Harvard-Physics
+    altaffil: []
+    initials: Peter
+    name: Doherty
+    orcid: null
+  dominguezm:
+    affil:
+    - IAFE
+    - CONICET
+    altaffil: []
+    initials: Mariano
+    name: Dominguez
+    orcid:
+  dinob:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Dino
+    name: Bektesevic
+    orcid: null
+  duboisfelsmanngp:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Gregory P.
+    name: Dubois-Felsmann
+    orcid: 0000-0003-1598-6979
+  duboisr:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Richard
+    name: Dubois
+    orcid: null
+  durechj:
+    affil:
+    - ChUniv
+    altaffil: []
+    initials: Josef
+    name: Durech
+    orcid: null
+  economouf:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Frossie
+    name: Economou
+    orcid: 0000-0002-8333-7615
+  eggls:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Siegfried
+    name: Eggl
+    orcid: 0000-0002-1398-6302
+  eiflert:
+    affil:
+    - UA-Steward
+    altaffil: []
+    initials: Tim
+    name: Eifler
+    orcid: null
+  emmonsbl:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Benjamin L.
+    name: Emmons
+    orcid: null
+  eracleousm:
+    affil:
+    - PSU
+    altaffil: []
+    initials: Michael
+    name: Eracleous
+    orcid: 0000-0002-3719-940X
+  evansj:
+    affil:
+    - Harvard-CfA
+    altaffil: []
+    initials: Janet D.
+    name: Evans
+    orcid: 0000-0003-3509-0870
+  fabbiang:
+    affil:
+    - CCA
+    - Cardiff
+    altaffil: []
+    initials: Giulio
+    name: Fabbian
+    orcid: 0000-0002-3255-4695
+  faginj:
+    affil:
+    - CUNY-Grad
+    altaffil: []
+    initials: Joshua
+    name: Fagin
+    orcid: null
+  faustinetoa:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Angelo
+    name: Fausti Neto
+    orcid: 0000-0002-8095-305X
+  fergusonh:
+    affil:
+    - STScI
+    altaffil: []
+    initials: Henry
+    name: Ferguson
+    orcid: 0000-0001-7113-2738
+  fergusonps:
+    affil:
+    - WisconsinMadison
+    altaffil: []
+    initials: Peter S.
+    name: Ferguson
+    orcid: 0000-0001-6957-1627
+  fertea:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Agn\`{e}s F.
+    name: Fert\'{e}
+    orcid: 0000-0003-3065-9941
+  fieldb:
+    affil:
+    - DOE
+    altaffil: []
+    initials: Bryan
+    name: Field
+    orcid: null
+  figueroae:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Enrique
+    name: Figueroa
+    orcid: null
+  findeisenk:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Krzysztof
+    name: Findeisen
+    orcid: 0000-0003-1898-5760
+  fisherlevinem:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Merlin
+    name: Fisher-Levine
+    orcid: 0000-0001-9440-8960
+  fockew:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Warren
+    name: Focke
+    orcid: null
+  fonsecaalvarezg:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Gloria
+    name: Fonseca Alvarez
+    orcid: 0000-0003-0042-6936
+  fords:
+    affil:
+    - CUNYBM
+    - AMNH
+    - CUNY-Grad
+    - CCA
+    altaffil: []
+    initials: K. E. Saavik
+    name: Ford
+    orcid: 0000-0002-5956-851X
+  foremand:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Dan
+    name: Foreman-Mackey
+    orcid: null
+  foreroj:
+    affil:
+    - UniAndes
+    altaffil: []
+    initials: Jaime
+    name: Forero-Romero
+    orcid: null
+  fossmd:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Michael D.
+    name: Foss
+    orcid: null
+  frankj:
+    affil:
+    - BNL
+    altaffil: []
+    initials: James
+    name: Frank
+    orcid: null
+  freemonmd:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Michael D.
+    name: Freemon
+    orcid: null
+  gaffneyn:
+    affil:
+    - TACC
+    altaffil: []
+    initials: Niall
+    name: Gaffney
+    orcid: null
+  gaglianoa:
+    affil:
+    - Illinois-astro
+    altaffil: []
+    initials: Alexander
+    name: Gagliano
+    orcid: 0000-0003-4906-8447
+  garaviton:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Nicol\'{a}s
+    name: Garavito Camargo
+    orcid: null
+  gallc:
+    affil:
+    - DARK
+    altaffil: []
+    initials: Christa
+    name: Gall
+    orcid: 0000-0002-8526-3963
+  ganglere:
+    affil:
+    - Clermont-LPC
+    altaffil: []
+    initials: Emmanuel
+    name: Gangler
+    orcid: 0000-0001-6728-1423
+  gaponenkoi:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Igor
+    name: Gaponenko
+    orcid: null
+  gatesj:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: John
+    name: Gates
+    orcid: null
+  gawisere:
+    affil:
+    - Rutgers
+    altaffil: []
+    initials: Eric
+    name: Gawiser
+    orcid: 0000-0003-1530-8713
+  gearyjc:
+    affil:
+    - SAO
+    altaffil: []
+    initials: John C.
+    name: Geary
+    orcid: null
+  geep:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: Perry
+    name: Gee
+    orcid: null
+  geham:
+    affil:
+    - Yale
+    altaffil: []
+    initials: Marla
+    name: Geha
+    orcid: 0000-0002-7007-9725
+  gessnercjb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Charles J. B.
+    name: Gessner
+    orcid: null
+  gezaris:
+    affil:
+    - STScI
+    altaffil: []
+    initials: Suvi
+    name: Gezari
+    orcid: null
+  gibsonrr:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Robert R.
+    name: Gibson
+    orcid: null
+  gilliesk:
+    affil:
+    - TMT
+    altaffil: []
+    initials: Kim
+    name: Gillies
+    orcid: null
+  gilmoredk:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: D. Kirk
+    name: Gilmore
+    orcid: null
+  glanzmant:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Thomas
+    name: Glanzman
+    orcid: 0000-0001-9649-3871
+  glickw:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: William
+    name: Glick
+    orcid: null
+  goldinat:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Tatiana
+    name: Goldina
+    orcid: null
+  goldsteinda:
+    affil:
+    - Berkeley-Astro
+    - Berkeley-LBNL
+    altaffil: []
+    initials: Daniel A.
+    name: Goldstein
+    orcid: 0000-0003-3461-8661
+  golkhouvz:
+    affil:
+    - JPMORGAN
+    altaffil: []
+    initials: V. Zach
+    name: Golkhou
+    orcid: null
+  gomboca:
+    affil:
+    - NovaGorica
+    altaffil: []
+    initials: Andreja
+    name: Gomboc
+    orcid: null
+  gonzalesa:
+    affil:
+    - CNCT
+    - UdG
+    altaffil: []
+    initials: Alma X.
+    name: Gonzalez-Morales
+    orcid: 0000-0003-4089-6924
+  goodenowi:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Iain
+    name: Goodenow
+    orcid: null
+  gowerm:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Michelle
+    name: Gower
+    orcid: 0000-0001-9513-6987
+  grahamml:
+    affil:
+    - Washington
+    - DIRAC
+    altaffil: []
+    initials: Melissa L.
+    name: Graham
+    orcid: 0000-0002-9154-3136
+  grahammm:
+    affil:
+    - Caltech-Astro
+    altaffil: []
+    initials: Matthew J.
+    name: Graham
+    orcid: 0000-0002-3168-0139
+  greenstreets:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Sarah
+    name: Greenstreet
+    orcid: 0000-0002-4439-1539
+  gresslerwj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: William J.
+    name: Gressler
+    orcid: null
+  grisp:
+    affil:
+    - Clermont-LPC
+    altaffil: []
+    initials: Philippe
+    name: Gris
+    orcid: null
+  gschwendj:
+    affil:
+    - LINEA
+    altaffil: []
+    initials: Julia
+    name: Gschwend
+    orcid: 0000-0003-3023-8362
+  guylp:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Leanne P.
+    name: Guy
+    orcid: 0000-0003-0800-8755
+  guyonneta:
+    affil:
+    - Harvard-Physics
+    altaffil: []
+    initials: Augustin
+    name: Guyonnet
+    orcid: null
+  gwyns:
+    affil:
+    - NRC
+    altaffil: []
+    initials: Steven
+    name: Gwyn
+    orcid: null
+  hallerg:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Gunther
+    name: Haller
+    orcid: null
+  hanushevskya:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Andrew
+    name: Hanushevsky
+    orcid: null
+  harrisr:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Ron
+    name: Harris
+    orcid: null
+  hascallpa:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Patrick A.
+    name: Hascall
+    orcid: null
+  hauptj:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Justine
+    name: Haupt
+    orcid: null
+  hennawij:
+    affil:
+    - UCSB
+    altaffil: []
+    initials: Joseph
+    name: Hennawi
+    orcid:
+  herrolda:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Ardis
+    name: Herrold
+    orcid:
+  hernandezf:
+    affil:
+    - Lyon-CC-IN2P3
+    altaffil: []
+    initials: Fabio
+    name: Hernandez
+    orcid: 0000-0001-7203-2552
+  herrmanns:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Sven
+    name: Herrmann
+    orcid: null
+  hilemane:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Edward
+    name: Hileman
+    orcid: null
+  hoblittj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Joshua
+    name: Hoblitt
+    orcid: 0000-0002-5292-5879
+  hodgsonja:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: John A.
+    name: Hodgson
+    orcid: null
+  hoganc:
+    affil:
+    - Chicago
+    altaffil: []
+    initials: Craig
+    name: Hogan
+    orcid: null
+  holleyk:
+    affil:
+    - Vdb
+    altaffil: []
+    initials: Kelly
+    name: Holley-Bockelmann
+    orcid: null
+  holmanmj:
+    affil:
+    - Harvard-CfA
+    altaffil: []
+    initials: Matthew J.
+    name: Holman
+    orcid: null
+  howardjd:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: James D.
+    name: Howard
+    orcid: null
+  hsiehh:
+    affil:
+    - PSI
+    altaffil: []
+    initials: Henry H.
+    name: Hsieh
+    orcid: 0000-0001-7225-9271
+  huangd:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Dajun
+    name: Huang
+    orcid: null
+  huangf:
+    affil:
+    - Google
+    altaffil: []
+    initials: Flora
+    name: Huang
+    email: huangflora@google.com
+    orcid: null
+  hughesa:
+    affil:
+    - NSO
+    altaffil: []
+    initials: Anna L.H.
+    name: Hughes
+    orcid: null
+  hufferme:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Michael E.
+    name: Huffer
+    orcid: null
+  hundertmarkm:
+    affil:
+    - Heidelberg
+    altaffil: []
+    initials: Markus
+    name: Hundertmark
+    orcid: 0000-0003-0961-5231
+  ilicd:
+    affil:
+    - Belgrade-Uni
+    - Hamburg
+    altaffil: []
+    initials: Dragana
+    name: Ili{\'c}
+    orcid: 0000-0002-1134-4015
+  ingrahamp:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Patrick
+    name: Ingraham
+    orcid: 0000-0003-3715-8138
+  inneswr:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Walter R.
+    name: Innes
+    orcid: null
+  ishidaeo:
+    affil:
+    - Clermont-LPC
+    altaffil: []
+    initials: Emille E. O.
+    name: Ishida
+    orcid: null
+  ivezicv:
+    affil:
+    - Washington
+    altaffil: []
+    initials: \v{Z}eljko
+    name: Ivezi\'{c}
+    orcid: 0000-0001-5250-2633
+  jacobysh:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Suzanne H.
+    name: Jacoby
+    orcid: null
+  jaffet:
+    affil:
+    - NASA
+    altaffil: []
+    initials: Tess
+    name: Jaffe
+    orcid: null
+  jagannathanp:
+    affil:
+    - NRAO
+    altaffil: []
+    initials: Preshanth
+    name: Jagannathan
+    orcid: null
+  jainb:
+    affil:
+    - UPenn
+    altaffil: []
+    initials: Bhuvnesh
+    name: Jain
+    orcid: null
+  jammesf:
+    affil:
+    - Clermont-LPC
+    altaffil: []
+    initials: Fabrice
+    name: Jammes
+    orcid: null
+  jeej:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: James
+    name: Jee
+    orcid: null
+  jennesst:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Tim
+    name: Jenness
+    orcid: 0000-0001-5982-167X
+  jernigang:
+    affil:
+    - Berkeley-Space
+    altaffil: []
+    initials: Garrett
+    name: Jernigan
+    orcid: null
+  jevremovicd:
+    affil:
+    - Belgrade-AO
+    altaffil: []
+    initials: Darko
+    name: Jevremovi\'{c}
+    orcid: null
+  johnsk:
+    affil:
+    - UA-Physics
+    altaffil: []
+    initials: Kenneth
+    name: Johns
+    orcid: null
+  johnsonas:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Anthony S.
+    name: Johnson
+    orcid: 0000-0002-5729-2716
+  johnsonmw:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Margaret W.G.
+    name: Johnson
+    orcid: null
+  jonesrl:
+    affil:
+    - Washington
+    altaffil: []
+    initials: R. Lynne
+    name: Jones
+    orcid: 0000-0001-5916-0031
+  juramygillesc:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Claire
+    name: Juramy-Gilles
+    orcid: null
+  juricm:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Mario
+    name: Juri\'{c}
+    orcid: 0000-0003-1996-9252
+  jurkict:
+    affil:
+    - URijeka
+    altaffil: []
+    initials: Tomislav
+    name: Jurki\'{c}
+    orcid: null
+  kahnsm:
+    affil:
+    - RubinObs
+    - SLAC-Kavli
+    altaffil: []
+    initials: Steven M.
+    name: Kahn
+    orcid: null
+  kaliraijs:
+    affil:
+    - STScI
+    altaffil: []
+    initials: Jason S.
+    name: Kalirai
+    orcid: null
+  kallivayalilnj:
+    affil:
+    - UVa
+    altaffil: []
+    initials: Nitya J.
+    name: Kallivayalil
+    orcid: 0000-0002-3204-1742
+  kalmbachb:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Bryce
+    name: Kalmbach
+    orcid: 0000-0002-6825-5283
+  kannawadia:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Arun
+    name: Kannawadi
+    orcid: 0000-0001-8783-6529
+  kantorjp:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Jeffrey P.
+    name: Kantor
+    orcid: null
+  karstp:
+    affil:
+    - CPPM
+    altaffil: []
+    initials: Pierre
+    name: Karst
+    orcid: null
+  kasliwalmm:
+    affil:
+    - Caltech-Astro
+    altaffil: []
+    initials: Mansi M.
+    name: Kasliwal
+    orcid: 0000-0002-5619-4938
+  kavelaarsjj:
+    affil:
+    - CADC
+    altaffil: []
+    initials: JJ
+    name: Kavelaars
+    orcid: null
+  keek:
+    affil:
+    - TTU-media
+    altaffil: []
+    initials: Kerk
+    name: Kee
+    orcid: null
+  kellyh:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Heather
+    name: Kelly
+    orcid: null
+  kelvinl:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Lee S.
+    name: Kelvin
+    orcid: 0000-0001-9395-4759
+  kernj:
+    affil:
+    - NRAO
+    altaffil: []
+    initials: Jeff
+    name: Kern
+    orcid: 0000-0003-3221-0419
+  kesslerr:
+    affil:
+    - Chicago
+    altaffil: []
+    initials: Richard
+    name: Kessler
+    orcid: 0000-0003-3221-0419
+  khineh:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Htut
+    name: Khine
+    orcid: null
+  kinnisonv:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Veronica
+    name: Kinnison
+    orcid: null
+  kirkbyd:
+    affil:
+    - UCIrvine-Astro
+    altaffil: []
+    initials: David
+    name: Kirkby
+    orcid: 0000-0002-8828-5463
+  knoxl:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: Lloyd
+    name: Knox
+    orcid: null
+  kosakowskia:
+    affil:
+    - TTU
+    altaffil: []
+    initials: Alekzander
+    name: Kosakowski
+    orcid: 0000-0002-9878-1647
+  kotoviv:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Ivan V.
+    name: Kotov
+    orcid: null
+  kovacevic:
+    affil:
+    - Belgrade-Uni
+    altaffil: []
+    initials: Andjelka B.
+    name: Kova{\v{c}}evi{\'c}
+    orcid: 0000-0001-5139-1978
+  kowalikm:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Mikolaj
+    name: Kowalik
+    orcid: 0000-0002-9801-5969
+  krabbendamvl:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Victor L.
+    name: Krabbendam
+    orcid: null
+  kremina:
+    affil:
+    - Berkeley-LBNL
+    altaffil: []
+    initials: Anthony
+    name: Kremin
+    orcid: null
+  krughoffks:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: K. Simon
+    name: Krughoff
+    orcid: 0000-0002-4410-7868
+  kubanekp:
+    affil:
+    - Praha-ASCR
+    altaffil: []
+    initials: Petr
+    name: Kub\'{a}nek
+    orcid: null
+  kubicaj:
+    affil:
+    - CMU
+    altaffil: []
+    initials: Jeremy
+    name: Kubica
+    orcid: null
+  kuczewskij:
+    affil:
+    - BNL
+    altaffil: []
+    initials: John
+    name: Kuczewski
+    orcid: null
+  kuj:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: John
+    name: Ku
+    orcid: null
+  kulkarnis:
+    affil:
+    - Caltech-Astro
+    altaffil: []
+    initials: Shri
+    name: Kulkarni
+    orcid: 0000-0001-5390-8563
+  kuritanr:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Nadine R.
+    name: Kurita
+    orcid: null
+  labriek:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Kathleen
+    name: Labrie
+    orcid: null
+  lacym:
+    affil:
+    - NRAO
+    altaffil: []
+    initials: Mark
+    name: Lacy
+    orcid: null
+  lagecs:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: Craig S.
+    name: Lage
+    orcid: null
+  lambertr:
+    affil:
+    - RubinObs
+    - CTIO
+    altaffil: []
+    initials: Ron
+    name: Lambert
+    orcid: null
+  langet:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Travis
+    name: Lange
+    orcid: null
+  langtonjb:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: J. Brian
+    name: Langton
+    orcid: null
+  lanussef:
+    affil:
+    - Saclay
+    altaffil: []
+    initials: Fran\c{c}ois
+    name: Lanusse
+    orcid: null
+  laur:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Ryan M.
+    name: Lau
+    orcid: 0000-0003-0778-0321
+  lawc:
+    affil:
+    - Caltech-Astro
+    altaffil: []
+    initials: Casey
+    name: Law
+    orcid: null
+  lazari:
+    affil:
+    - Herts
+    altaffil: []
+    initials: Ilin
+    name: Lazar
+    orcid: null
+  leguilloul:
+    affil:
+    - Paris-UPMC
+    - Paris-LPNHE
+    altaffil: []
+    initials: Laurent
+    name: Le Guillou
+    orcid: null
+  levined:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Deborah
+    name: Levine
+    orcid: null
+  levinewg:
+    affil:
+    - Yale
+    altaffil: []
+    initials: W. Garrett
+    name: Levine
+    orcid: null
+  liangm:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Ming
+    name: Liang
+    orcid: null
+  limk:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Kian-Tat
+    name: Lim
+    orcid: 0000-0002-6338-6516
+  lix:
+    affil:
+    - Delaware-PhyAst
+    altaffil: []
+    initials: Xiaolong
+    name: Li
+    orcid: 0000-0002-0514-5650
+  lintottcj:
+    affil:
+    - Oxford
+    altaffil: []
+    initials: Chris J.
+    name: Lintott
+    orcid: 0000-0001-5578-359X
+  longke:
+    affil:
+    - Longhorn
+    altaffil: []
+    initials: Kevin E.
+    name: Long
+    orcid: null
+  lopezm:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Margaux
+    name: Lopez
+    orcid: null
+  lotzpj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Paul J.
+    name: Lotz
+    orcid: null
+  luj:
+    affil:
+    - FSU
+    altaffil: []
+    initials: Jing
+    name: Lu
+    orcid:
+  lunagjm:
+    affil:
+    - IAFE
+    - CONICET
+    altaffil: []
+    initials: Gerardo Juan Manuel
+    name: Luna
+    orcid: 0000-0002-2647-4373
+  luptonrh:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Robert H.
+    name: Lupton
+    orcid: 0000-0003-1666-0962
+  lustnb:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Nate B.
+    name: Lust
+    orcid: 0000-0002-4122-9384
+  macarthurla:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Lauren A.
+    name: MacArthur
+    orcid: null
+  madejskig:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Greg M.
+    name: Madejski
+    orcid: null
+  mahabala:
+    affil:
+    - Caltech
+    - Caltech-CDDD
+    altaffil: []
+    initials: Ashish A.
+    name: Mahabal
+    orcid: 0000-0003-2242-0244
+  malza:
+    affil:
+    - GCCL
+    - CMU
+    altaffil: []
+    initials: Alex I.
+    name: Malz
+    orcid: 0000-0002-8676-1622
+  mandelbaumr:
+    affil:
+    - CMU
+    altaffil: []
+    initials: Rachel
+    name: Mandelbaum
+    orcid: 0000-0003-2271-1527
+  maoy:
+    affil:
+    - Rutgers
+    - Utah
+    altaffil: []
+    initials: Yao-Yuan
+    name: Mao
+    orcid: 0000-0002-1200-0820
+  markiewicztw:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Thomas W.
+    name: Markiewicz
+    orcid: 0000-0003-3646-8724
+  marshallpj:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Philip J.
+    name: Marshall
+    orcid: null
+  marshalls:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Stuart
+    name: Marshall
+    orcid: null
+  masciarellij:
+    affil:
+    - Google
+    altaffil: []
+    initials: Jess
+    name: Masciarelli
+    orcid: null
+  masonb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Blake
+    name: Mason
+    orcid: null
+  marshds:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Darren S.
+    name: Marsh
+    orcid: null
+  martinezm:
+    affil:
+    - WisconsinMadison
+    altaffil: []
+    initials: Michael N.
+    name: Martinez
+    orcid: 0000-0002-8397-8412
+  martinezr:
+    affil:
+    - Harvard-Astro
+    altaffil: []
+    initials: Rafael
+    name: Mart\'{i}nez-Galarza
+    orcid: null
+  maym:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Morgan
+    name: May
+    orcid: null
+  mccullyc:
+    affil:
+    - CUMBRES
+    altaffil: []
+    initials: Curtis
+    name: McCully
+    orcid: null
+  mceneryj:
+    affil:
+    - NASA
+    altaffil: []
+    initials: Julie
+    name: McEnery
+    orcid: null
+  mckercherr:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Robert
+    name: McKercher
+    orcid: null
+  mcqueenm:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Michelle
+    name: McQueen
+    orcid: null
+  medani:
+    affil:
+    - GeorgiaState
+    altaffil: []
+    initials: Ilija
+    name: Medan
+    orcid: null
+  meisnera:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Aaron M.
+    name: Meisner
+    orcid: 0000-0002-1125-7384
+  menanteauf:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Felipe
+    name: Menanteau
+    orcid: null
+  meyersj:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Joshua
+    name: Meyers
+    orcid: 0000-0002-2308-4230
+  migliorem:
+    affil:
+    - Grenoble-LPSC
+    altaffil: []
+    initials: Myriam
+    name: Migliore
+    orcid: null
+  millera:
+    affil:
+    - CIERA
+    altaffil: []
+    initials: Adam A.
+    name: Miller
+    orcid: 0000-0001-9515-478X
+  millerb:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Bryan
+    name: Miller
+    orcid: null
+  millerm:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Michelle
+    name: Miller
+    orcid: null
+  millsdj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: David J.
+    name: Mills
+    orcid: null
+  miravalc:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Connor
+    name: Miraval
+    orcid: null
+  moeyensj:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Joachim
+    name: Moeyens
+    orcid: 0000-0001-5820-3925
+  mondrikn:
+    affil:
+    - Harvard-Physics
+    altaffil: []
+    initials: Nicholas
+    name: Mondrik
+    orcid: null
+  monetdg:
+    affil:
+    - USNO
+    altaffil: []
+    initials: David G.
+    name: Monet
+    orcid: null
+  moniezm:
+    affil:
+    - Paris-LAL
+    altaffil: []
+    initials: Marc
+    name: Moniez
+    orcid: null
+  monkewitzs:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Serge
+    name: Monkewitz
+    orcid: null
+  montgomeryc:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Christopher
+    name: Montgomery
+    orcid: null
+  moolekampfe:
+    affil:
+    - Rider
+    - Princeton-Astro
+    altaffil: []
+    initials: Fred E.
+    name: Moolekamp
+    orcid: 0000-0003-0093-4279
+  moriartyc:
+    affil:
+    - Harvard-CfA
+    altaffil: []
+    initials: Christopher
+    name: Moriarty
+    orcid: null
+  morrisoncb:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Christopher B.
+    name: Morrison
+    orcid: null
+  muellerf:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Fritz
+    name: Mueller
+    orcid: 0000-0002-7061-4644
+  muencha:
+    affil:
+    - AAS
+    altaffil: []
+    initials: August
+    name: Muench
+    orcid: null
+  mullergp:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Gary P.
+    name: Muller
+    orcid: null
+  munad:
+    affil:
+    - NASA
+    altaffil: []
+    initials: Demitri
+    name: Muna
+    orcid: null
+  munozarancibiaf:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Freddy
+    name: Mu\~noz Arancibia
+    orcid: null
+  murilloa:
+    affil:
+    - IUPUI
+    altaffil: []
+    initials: Angela
+    name: Murillo
+    orcid: null
+  narayananks:
+    affil:
+    - Cochin
+    altaffil: []
+    initials: Sathya
+    name: Narayanan K
+    orcid: null
+  narayang:
+    affil:
+    - Illinois
+    altaffil: []
+    initials: Gautham
+    name: Narayan
+    orcid: null
+  neilldr:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Douglas R.
+    name: Neill
+    orcid: null
+  neilljd:
+    affil:
+    - Caltech
+    altaffil: []
+    initials: James D.
+    name: Neill
+    orcid: null
+  neilsene:
+    affil:
+    - Fermilab
+    altaffil: []
+    initials: Eric H.
+    name: Neilsen, Jr.
+    orcid: 0000-0002-7357-0317
+  newbrysp:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Scott P.
+    name: Newbry
+    orcid: null
+  niefj:
+    affil:
+    - Lyon-CC-IN2P3
+    altaffil: []
+    initials: Jean-Yves
+    name: Nief
+    orcid: null
+  nikolicm:
+    affil:
+    - Belgrade-Uni
+    altaffil: []
+    initials: Mladen
+    name: Nicoli\'{c}
+    orcid: null
+  nikuttar:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Robert
+    name: Nikutta
+    orcid: 0000-0002-7052-6900
+  nima:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Nima
+    name: Sedaghat
+    orcid: 0000-0003-4734-2019
+  nomerotskia:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Andrei
+    name: Nomerotski
+    orcid: null
+  nordb:
+    affil:
+    - Fermi
+    - Chicago
+    altaffil: []
+    initials: Brian
+    name: Nord
+    orcid: 0000-0001-6706-8972
+  nordbym:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Martin
+    name: Nordby
+    orcid: null
+  normand:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Dara
+    name: Norman
+    orcid: 0000-0001-8452-9574
+  oconnorp:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Paul
+    name: O'Connor
+    orcid: null
+  odowdm:
+    affil:
+    - CUNYL
+    - AMNH
+    altaffil: []
+    initials: Matt
+    name: O'Dowd
+    orcid: null
+  ojhar:
+    affil:
+    - NASA
+    altaffil: []
+    initials: Roopesh
+    name: Ojha
+    orcid: null
+  oliverj:
+    affil:
+    - Harvard-Physics
+    - Harvard-Astro
+    altaffil: []
+    initials: John
+    name: Oliver
+    orcid: null
+  olivierss:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Scot S.
+    name: Olivier
+    orcid: null
+  olsenc:
+    affil:
+    - Rutgers
+    altaffil: []
+    initials: Charlotte
+    name: Olsen
+    orcid:
+  olsenk:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Knut
+    name: Olsen
+    orcid: 0000-0002-7134-8296
+  omearaj:
+    affil:
+    - KECK
+    altaffil: []
+    initials: John
+    name: O'Meara
+    orcid: null
+  omullanew:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: William
+    name: O'Mullane
+    orcid: 0000-0003-4141-6195
+    email: womullan@lsst.org
+  ortizs:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Sandra
+    name: Ortiz
+    orcid: null
+  osiers:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Shawn
+    name: Osier
+    orcid: null
+  owenre:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Russell E.
+    name: Owen
+    orcid: null
+  padolskis:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Sergey
+    name: Padolski
+    orcid: null
+  painr:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Reynald
+    name: Pain
+    orcid: null
+  palecekpe:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Paul E.
+    name: Palecek
+    orcid: null
+  parejkojk:
+    affil:
+    - Washington
+    altaffil: []
+    initials: John K.
+    name: Parejko
+    orcid: null
+  parsonsjb:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: James B.
+    name: Parsons
+    orcid: null
+  pearsons:
+    affil:
+    - NYU-CCPP
+    altaffil: []
+    initials: Sarah
+    name: Pearson
+    orcid: 0000-0001-5049-5396
+  peasenm:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Nathan M.
+    name: Pease
+    orcid: 0000-0002-9701-5975
+  pedrazaiv:
+    affil:
+    - DACC
+    altaffil: []
+    initials: Ilhuiyolitzin
+    name: Villicana Pedraza
+    orcid: 0000-0002-9632-3132
+  petersonjm:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: J. Matt
+    name: Peterson
+    orcid: 0000-0002-6564-6246
+  petersonjr:
+    affil:
+    - Purdue-Astro
+    altaffil: []
+    initials: John R.
+    name: Peterson
+    orcid: 0000-0001-5471-9609
+  petravickdl:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Donald L.
+    name: Petravick
+    orcid: null
+  petrickml:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: M.E. Libby
+    name: Petrick
+    orcid: null
+  petryce:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Cathy E.
+    name: Petry
+    orcid: null
+  pierfedericif:
+    affil:
+    - IRAM
+    altaffil: []
+    initials: Francesco
+    name: Pierfederici
+    orcid: null
+  pietrowiczs:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Stephen
+    name: Pietrowicz
+    orcid: null
+  piker:
+    affil:
+    - Google
+    altaffil: []
+    initials: Rob
+    name: Pike
+    orcid: null
+  pintopa:
+    affil:
+    - UA-Steward
+    altaffil: []
+    initials: Philip A.
+    name: Pinto
+    orcid: null
+  planter:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Raymond
+    name: Plante
+    orcid: null
+  plates:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Stephen
+    name: Plate
+    orcid: null
+  plazasa:
+    affil:
+    - SLAC
+    - SLAC-Kavli
+    altaffil: []
+    initials: Andr\'es A.
+    name: Plazas Malag\'on
+    orcid: 0000-0002-2598-0514
+  plutchakjp:
+    affil:
+    - NCSA
+    altaffil: []
+    initials: Joel P.
+    name: Plutchak
+    orcid: 0000-0002-1501-825X
+  popinchalkm:
+    affil:
+    - CUNYAMNH
+    altaffil: []
+    initials: Mark
+    name: Popinchalk
+    orcid: null
+  popovicl:
+    affil:
+    - Belgrade-AO
+    - Belgrade-Uni
+    altaffil: []
+    initials: Luka {\v{C}}.
+    name: Popovi\'c
+    orcid: null
+  pricepa:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Paul A.
+    name: Price
+    orcid: null
+  pricewhelana:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Adrian
+    name: Price-Whelan
+    orcid: 0000-0003-0872-7098
+  pritchardita:
+    affil:
+    - NYU-CCPP
+    altaffil: []
+    initials: Tyler A.
+    name: Pritchard
+    orcid: null
+  prouzam:
+    affil:
+    - Praha-ASCR
+    altaffil: []
+    initials: Michael
+    name: Prouza
+    orcid: null
+  quintb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Bruno C.
+    name: Quint
+    orcid: 0000-0002-1557-3560
+  radekav:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Veljko
+    name: Radeka
+    orcid: null
+  radovicv:
+    affil:
+    - Belgrade-Uni
+    altaffil: []
+    initials: Viktor
+    name: Radovi\'{c}
+    orcid: null
+  ragostaf:
+    affil:
+    - INAF-Rome
+    altaffil: []
+    initials: Fabio
+    name: Ragosta
+    orcid: null
+  ribeirot:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Tiago
+    name: Ribeiro
+    orcid: null
+  ricciog:
+    affil:
+    - NCNRP
+    altaffil: []
+    initials: Gabriele
+    name: Riccio
+    orcid: null
+  rileya:
+    affil:
+    - TAMU-inst
+    - TAMU
+    altaffil: []
+    initials: Alexander H.
+    name: Riley
+    orcid: 0000-0001-5805-5766
+  riveram:
+    affil:
+    - RubinObsC
+    altaffil: []
+    initials: Mario
+    name: Rivera
+    orcid: null
+  rizzil:
+    affil:
+    - NSF
+    altaffil: []
+    initials: Luca
+    name: Rizzi
+    orcid: null
+  rajagopalj:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Jayadev
+    name: Rajagopal
+    orcid: null
+  rasmussenap:
+    affil:
+    - Purdue-Astro
+    altaffil: []
+    initials: Andrew P.
+    name: Rasmussen
+    orcid: null
+  reeds:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Sophie L.
+    name: Reed
+    orcid: 0000-0002-4422-0553
+  regnaultn:
+    affil:
+    - Paris-LPNHE
+    altaffil: []
+    initials: Nicolas
+    name: Regnault
+    orcid: null
+  reilka:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Kevin A.
+    name: Reil
+    orcid: null
+  reissdj:
+    affil:
+    - Washington
+    altaffil: []
+    initials: David J.
+    name: Reiss
+    orcid: null
+  reuterma:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Michael A.
+    name: Reuter
+    orcid: 0000-0003-3881-8310
+  ridgwayst:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Stephen T.
+    name: Ridgway
+    orcid: 0000-0003-2557-7132
+  riotvj:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Vincent J.
+    name: Riot
+    orcid: null
+  ritzs:
+    affil:
+    - UCSC
+    altaffil: []
+    initials: Steve
+    name: Ritz
+    orcid: null
+  robertsa:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Austin
+    name: Roberts
+    orcid: null
+  robinsons:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Sean
+    name: Robinson
+    orcid: null
+  robyw:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: William
+    name: Roby
+    orcid: null
+  roodmana:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Aaron
+    name: Roodman
+    orcid: 0000-0001-5326-3486
+  rosingw:
+    affil:
+    - CUMBRES
+    altaffil: []
+    initials: Wayne
+    name: Rosing
+    orcid: null
+  roucellec:
+    affil:
+    - Paris-APC
+    altaffil: []
+    initials: Cecille
+    name: Roucelle
+    orcid: null
+  rozeka:
+    affil:
+    - EdinburghIA
+    altaffil: []
+    initials: Agata
+    name: Ro\.{z}ek
+    orcid: 0000-0003-2341-2238
+  rumoremr:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Matthew R.
+    name: Rumore
+    orcid: null
+  rusholmeb:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Ben
+    name: Rusholme
+    orcid: null
+  russos:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Stefano
+    name: Russo
+    orcid: null
+  rykoffe:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Eli S.
+    name: Rykoff
+    orcid: 0000-0001-9376-3135
+  saccot:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Timothy
+    name: Sacco
+    orcid: 0000-0002-0921-2187
+  sahaa:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Abhijit
+    name: Saha
+    orcid: 0000-0002-5091-0470
+  salnikova:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Andrei
+    name: Salnikov
+    orcid: 0000-0002-3623-0161
+  sanchezsaezp:
+    affil:
+    - ESO
+    altaffil: []
+    initials: Paula
+    name: S\'anchez-S\'aez
+    orcid: 0000-0003-0820-4692
+  sarrol:
+    affil:
+    - UNED
+    altaffil: []
+    initials: Luis M.
+    name: Sarro
+    orcid: 0000-0002-5622-5191
+  # Note: the savicd entry requires \usepackage[T1]{fontenc} to include Serbian accents.
+  savicd:
+    affil:
+    - Liege
+    - Belgrade-AO
+    altaffil: []
+    initials: \DJ{}or\dj{}e V.
+    name: Savi\'c
+    orcid: 0000-0003-0880-8963
+  assolasb:
+    affil:
+    - Lyon-LMA-IN2P3
+    altaffil: []
+    initials: Benoit
+    name: Sassolas
+    orcid: null
+  saundersc:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Clare
+    name: Saunders
+    orcid: 0000-0002-4094-2102
+  schalktl:
+    affil:
+    - UCSC
+    altaffil: []
+    initials: Terry L.
+    name: Schalk
+    orcid: null
+  schellartp:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Pim
+    name: Schellart
+    orcid: 0000-0002-8324-0880
+  schindlerrh:
+    affil:
+    - SLAC-Kavli
+    altaffil: []
+    initials: Rafe H.
+    name: Schindler
+    orcid: null
+  schmidts:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: Samuel
+    name: Schmidt
+    orcid: null
+  schneiderdp:
+    affil:
+    - PSU
+    altaffil: []
+    initials: Donald P.
+    name: Schneider
+    orcid: null
+  schneidermd:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Michael D.
+    name: Schneider
+    orcid: 0000-0002-8505-7094
+  schoeningw:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: William
+    name: Schoening
+    orcid: null
+  schumacherg:
+    affil:
+    - RubinObs
+    - CTIO
+    altaffil: []
+    initials: German
+    name: Schumacher
+    orcid: null
+  schwambme:
+    affil:
+    - GeminiN
+    altaffil: []
+    initials: Megan E.
+    name: Schwamb
+    orcid: 0000-0003-4365-1455
+  scotta:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Adam
+    name: Scott
+    orcid: null
+  seamanr:
+    affil:
+    - UA
+    altaffil: []
+    initials: Robert
+    name: Seaman
+    orcid: null
+  sebagj:
+    affil:
+    - RubinObsC
+    altaffil: []
+    initials: Jacques
+    name: Sebag
+    orcid: null
+  selvyb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Brian
+    name: Selvy
+    orcid: null
+  sembroskigh:
+    affil:
+    - Purdue-Astro
+    altaffil: []
+    initials: Glenn H.
+    name: Sembroski
+    orcid: null
+  seppalalg:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Lynn G.
+    name: Seppala
+    orcid: null
+  serioa:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Andrew
+    name: Serio
+    orcid: null
+  serranoe:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Eduardo
+    name: Serrano
+    orcid: null
+  shawra:
+    affil:
+    - STScI
+    altaffil: []
+    initials: Richard A.
+    name: Shaw
+    orcid: null
+  shirleyr:
+    affil:
+    - Southampton
+    altaffil: []
+    initials: Raphael
+    name: Shirley
+    orcid: null
+  shipseyi:
+    affil:
+    - Oxford
+    altaffil: []
+    initials: Ian
+    name: Shipsey
+    orcid: null
+  sickj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Jonathan
+    name: Sick
+    orcid: 0000-0003-3001-676X
+  silvac:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Cristian
+    name: Silva
+    orcid: null
+  silvestrin:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Nicole
+    name: Silvestri
+    orcid: null
+  slaterct:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Colin T.
+    name: Slater
+    orcid: 0000-0002-0558-0521
+  smithja:
+    affil:
+    - Peay
+    altaffil: []
+    initials: J. Allyn
+    name: Smith
+    orcid: null
+  smithrc:
+    affil:
+    - CTIO
+    altaffil: []
+    initials: R. Chris
+    name: Smith
+    orcid: null
+  smothermanh:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Hayden R.
+    name: Smotherman
+    orcid: 0000-0002-7895-4344
+  sobhanis:
+    affil:
+    - Belldex
+    altaffil: []
+    initials: Shahram
+    name: Sobhani
+    orcid: null
+  sokoloskij:
+    affil:
+    - LSSTC
+    - Columbia
+    altaffil: []
+    initials: J. L.
+    name: Sokoloski
+    orcid: null
+  soldahlc:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Christine
+    name: Soldahl
+    orcid: null
+  speckd:
+    affil:
+    - Burwood
+    altaffil: []
+    initials: Dan
+    name: Speck
+    email: dspeck@burwood.com
+    orcid: null
+  stalderb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Brian
+    name: Stalder
+    orcid: null
+  starkmann:
+    affil:
+    - UToronto
+    altaffil: []
+    initials: Nathaniel
+    name: Starkman
+    orcid: null
+  stetzlers:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Steven
+    name: Stetzler
+    orcid: null
+  stillm:
+    affil:
+    - NSF
+    altaffil: []
+    initials: Martin
+    name: Still
+    orcid: null
+  stoehrf:
+    affil:
+    - ESO
+    altaffil: []
+    initials: Felix
+    name: Stoehr
+    orcid: null
+  storrielombardil:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Lisa
+    name: Storrie-Lombardi
+    orcid: null
+  storeyfisherk:
+    affil:
+    - NYU-CCPP
+    altaffil: []
+    initials: Kate
+    name: Storey-Fisher
+    orcid: 0000-0001-8764-7103
+  stovere:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Edward
+    name: Stover
+    orcid: null
+  straussma:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Michael A.
+    name: Strauss
+    orcid: 0000-0002-0106-7755
+  streetra:
+    affil:
+    - CUMBRES
+    altaffil: []
+    initials: Rachel A.
+    name: Street
+    orcid: 0000-0001-6279-0552
+  stubbscw:
+    affil:
+    - Harvard-Physics
+    - Harvard-Astro
+    altaffil: []
+    initials: Christopher W.
+    name: Stubbs
+    orcid: 0000-0003-0347-1724
+  suberlakc:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Chris
+    name: Suberlak
+    orcid: null
+  sullivanis:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Ian S.
+    name: Sullivan
+    orcid: 0000-0001-8708-251X
+  sweeneyd:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Donald
+    name: Sweeney
+    orcid: null
+  swinbankjd:
+    affil:
+    - ASTRON
+    - Princeton-Astro
+    altaffil: []
+    initials: John D.
+    name: Swinbank
+    orcid: 0000-0001-9445-1846
+  szalaya:
+    affil:
+    - JHU
+    altaffil: []
+    initials: Alexander
+    name: Szalay
+    orcid: null
+  takacsp:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Peter
+    name: Takacs
+    orcid: null
+  taranuds:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Dan S.
+    name: Taranu
+    orcid: 0000-0001-6268-1882
+  tethersa:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Stephen A.
+    name: Tether
+    orcid: null
+  teubenp:
+    affil:
+    - Maryland
+    altaffil: []
+    initials: Peter
+    name: Teuben
+    orcid: null
+  thalerjj:
+    affil:
+    - Illinois
+    altaffil: []
+    initials: Jon J.
+    name: Thaler
+    orcid: null
+  thayerjg:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: John Gregg
+    name: Thayer
+    orcid: null
+  theboa:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Thebo
+    name: Adrein
+    orcid: null
+  thomass:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Sandrine
+    name: Thomas
+    orcid: 0000-0002-9121-3436
+  thorntonaj:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Adam J.
+    name: Thornton
+    orcid: 0000-0001-9342-6032
+  thukralv:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Vaikunth
+    name: Thukral
+    orcid: null
+  ticej:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Jeffrey
+    name: Tice
+    orcid: null
+  tigher:
+    affil:
+    - RubinObsC
+    altaffil: []
+    initials: Roberto
+    name: Tighe
+    orcid: null
+  toledoi:
+    affil:
+    - ALMA
+    altaffil: []
+    initials: Ignacio
+    name: Toledo
+    orcid: null
+  tollerude:
+    affil:
+    - STScI
+    altaffil: []
+    initials: Erik
+    name: Tollerud
+    orcid: null
+  torresn:
+    affil:
+    - CUNY
+    altaffil: []
+    initials: Nathalia
+    name: Torres
+    orcid: null
+  trillingde:
+    affil:
+    - NAU
+    altaffil: []
+    initials: David E.
+    name: Trilling
+    orcid: 0000-0003-4580-3790
+  tsait:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Te-Wei
+    name: Tsai
+    orcid: null
+  tsaprasy:
+    affil:
+    - Heidelberg
+    altaffil: []
+    initials: Yiannis
+    name: Tsapras
+    orcid: 0000-0001-8411-351X
+  tuckerdl:
+    affil:
+    - Fermilab
+    altaffil: []
+    initials: Douglas L.
+    name: Tucker
+    orcid: 0000-0001-7211-5729
+  turnerj:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: James
+    name: Turner
+    orcid: null
+  turkm:
+    affil:
+    - Illinois
+    altaffil: []
+    initials: Matthew D.
+    name: Turk
+    orcid: null
+  turrim:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Max
+    name: Turri
+    orcid: null
+  tysonja:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: J. Anthony
+    name: Tyson
+    orcid: 0000-0002-9242-8797
+  ustamujics:
+    affil:
+    - INAF-Palermo
+    altaffil: []
+    initials: Sabina
+    name: Ustamujic
+    orcid: 0000-0003-4596-2628
+  vanbergr:
+    affil:
+    - SLAC
+    - UPenn
+    altaffil: []
+    initials: Richard
+    name: Van Berg
+    orcid: null
+  vaccaw:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: William
+    name: Vacca
+    orcid: null
+  vandenberkd:
+    affil:
+    - SVC
+    altaffil: []
+    initials: Daniel
+    name: Vanden Berk
+    orcid: null
+  vanklaverenb:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Brian
+    name: Van Klaveren
+    orcid: null
+  vanvelzens:
+    affil:
+    - Lieden
+    altaffil: []
+    initials: Sjoert
+    name: van Velzen
+    orcid: null
+  vazquezm:
+    affil:
+    - UNAM-physics
+    - UNAM-astro
+    altaffil: []
+    initials: Jos\'e Antonio
+    name: V\'azquez-Mata
+    orcid: 0000-0001-8694-1204
+  venutil:
+    affil:
+    - SETI
+    altaffil: []
+    initials: Laura
+    name: Venuti
+    orcid: 0000-0002-4115-0318
+  vetterk:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Kurt
+    name: Vetter
+    orcid: null
+  vieiraj:
+    affil:
+    - Illinois-astro
+    altaffil: []
+    initials: Joaquin
+    name: Vieira
+    orcid: null
+  villalobosa:
+    affil:
+    - FacebookNE
+    altaffil: []
+    initials: Andres
+    name: Villalobos
+    orcid: null
+  villara:
+    affil:
+    - PSU
+    - PSUCDS
+    - PSUGC
+    altaffil: []
+    initials: Ashley
+    name: Villar
+    orcid: 0000-0002-5814-4061
+  virieuxf:
+    affil:
+    - Paris-APC
+    altaffil: []
+    initials: Francoise
+    name: Virieux
+    orcid: null
+  vucinat:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Tomislav
+    name: Vucina
+    orcid: null
+  wahlw:
+    affil:
+    - BNL
+    altaffil: []
+    initials: William
+    name: Wahl
+    orcid: null
+  walkowiczl:
+    affil:
+    - LOC
+    - Adler
+    altaffil: []
+    initials: Lucianne
+    name: Walkowicz
+    orcid: 0000-0003-2918-8687
+  walshb:
+    affil:
+    - BNL
+    altaffil: []
+    initials: Brian
+    name: Walsh
+    orcid: 0000-0001-7426-5413
+  waltercw:
+    affil:
+    - Duke
+    altaffil: []
+    initials: Christopher W.
+    name: Walter
+    orcid: 0000-0003-2035-2380
+  wangdl:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Daniel L.
+    name: Wang
+    orcid: null
+  wangs:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Shin-Yawn
+    name: Wang
+    orcid: null
+  warnerm:
+    affil:
+    - CTIO
+    altaffil: []
+    initials: Michael
+    name: Warner
+    orcid: null
+  watersc:
+    affil:
+    - Princeton-Astro
+    altaffil: []
+    initials: Christopher Z.
+    name: Waters
+    orcid: 0000-0003-1989-4879
+  weaverb:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Benjamin
+    name: Weaver
+    orcid: null
+  westfallk:
+    affil:
+    - UCO
+    altaffil: []
+    initials: Kyle
+    name: Westfall
+    orcid: null
+  wiechao:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Oliver
+    name: Wiecha
+    orcid: null
+  weinerb:
+    affil:
+    - MMTO
+    altaffil: []
+    initials: Benjamin
+    name: Weiner
+    orcid: null
+  weissj:
+    affil:
+    - TMT
+    altaffil: []
+    initials: Jason
+    name: Weiss
+    orcid: null
+  williamscc:
+    affil:
+    - NOIRLab
+    altaffil: []
+    initials: Christina C.
+    name: Williams
+    orcid: 0000-0003-2919-7495
+  willmanb:
+    affil:
+    - RubinObs
+    - UA-Steward
+    altaffil: []
+    initials: Beth
+    name: Willman
+    orcid: 0000-0003-2892-9906
+  wintersse:
+    affil:
+    - LLNL
+    altaffil: []
+    initials: Scott E.
+    name: Winters
+    orcid: null
+  wittmand:
+    affil:
+    - UCDavis
+    altaffil: []
+    initials: David
+    name: Wittman
+    orcid: 0000-0002-0813-5888
+  wolfej:
+    affil:
+    - SLAC
+    altaffil: []
+    initials: Justin
+    name: Wolfe
+    orcid:
+  wolffsc:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Sidney C.
+    name: Wolff
+    orcid: null
+  woodvaseywm:
+    affil:
+    - Pitts
+    altaffil: []
+    initials: W. Michael
+    name: Wood-Vasey
+    orcid: 0000-0001-7113-1233
+  wux:
+    affil:
+    - IPAC
+    altaffil: []
+    initials: Xiuqin
+    name: Wu
+    orcid: null
+  wyatts:
+    affil:
+    - Washington-Dirac
+    altaffil: []
+    initials: Samuel
+    name: Wyatt
+    orcid: null
+  xinb:
+    affil:
+    - RubinObs
+    altaffil: []
+    initials: Bo
+    name: Xin
+    orcid: 0000-0002-9171-4046
+  yoachimp:
+    affil:
+    - Washington
+    altaffil: []
+    initials: Peter
+    name: Yoachim
+    orcid: 0000-0003-2874-6464
+  yuw:
+    affil:
+    - Drexel
+    altaffil: []
+    initials: Weixiang
+    name: Yu
+    orcid: null
+  zabludoffa:
+    affil:
+    - UA-Astro
+    altaffil: []
+    initials: Ann
+    name: Zabludoff
+    orcid: 0000-0001-6047-8469
+  zhanh:
+    affil:
+    - KLOA
+    altaffil: []
+    initials: Hu
+    name: Zhan
+    orcid: null
+  zhaol:
+    affil:
+    - CCA
+    altaffil: []
+    initials: Lily
+    name: Zhao
+    orcid: null

--- a/tests/services/technotemigration_test.py
+++ b/tests/services/technotemigration_test.py
@@ -1,0 +1,73 @@
+"""Test the TechnoteMigrationService class."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+import yaml
+
+from documenteer.services.technotemigration import TechnoteMigrationService
+from documenteer.storage.authordb import AuthorDb
+from documenteer.storage.technotetoml import TechnoteTomlFile
+
+
+@pytest.fixture
+def author_db_yaml() -> str:
+    """Return the path to a sample authordb.yaml file."""
+    return (
+        Path(__file__).parent.parent / "data" / "authordb.yaml"
+    ).read_text()
+
+
+def test_migration(tmp_path: Path, author_db_yaml: str) -> None:
+    """Test migrating a technote."""
+    metadata = {
+        "series": "SQR",
+        "serial_number": "065",
+        "doc_title": "Design of Noteburst",
+        "description": "Hello world.",
+        "github_url": "https://github.com/lsst-sqre/sqr-065",
+    }
+
+    content = """
+:tocdepth: 1
+
+.. Please do not modify tocdepth.
+
+.. sectnum::
+
+Introduction
+============
+
+Hello
+
+.. rubric:: References
+
+.. bibliography:: local.bib lsstbib/books.bib
+   :style: lsst_aa
+"""
+
+    metadata_path = tmp_path / "metadata.yaml"
+    metadata_path.write_text(yaml.dump(metadata))
+
+    content_path = tmp_path / "index.rst"
+    content_path.write_text(content)
+
+    author_db = AuthorDb.from_yaml(author_db_yaml)
+    service = TechnoteMigrationService(tmp_path, author_db)
+    service.migrate(author_ids=["sickj"])
+
+    toml_path = tmp_path / "technote.toml"
+    assert toml_path.exists()
+    print(toml_path.read_text())
+
+    toml_file = TechnoteTomlFile.open(toml_path)
+    assert cast(str, toml_file.technote_table["id"]) == "SQR-065"
+    assert cast(str, toml_file.technote_table["series_id"]) == "SQR"
+    assert toml_file.author_ids == ["sickj"]
+
+    print(content_path.read_text())
+
+    # assert False

--- a/tests/storage/authordb_test.py
+++ b/tests/storage/authordb_test.py
@@ -24,11 +24,11 @@ def test_from_yaml(author_db_yaml: str) -> None:
     author = author_db.get_author("sickj")
     assert author.family_name == "Sick"
     assert author.given_name == "Jonathan"
-    assert author.orcid == "https://orcid.org/0000-0003-3001-676X"
-    assert author.affiliation_id == "RubinObs"
     assert author.author_id == "sickj"
+    assert author.orcid == "https://orcid.org/0000-0003-3001-676X"
+    assert author.affiliations[0].id == "RubinObs"
     assert (
-        author.affiliation_address
+        author.affiliations[0].address
         == "950 N. Cherry Ave., Tucson, AZ 85719, USA"
     )
-    assert author.affiliation_name == "Rubin Observatory Project Office"
+    assert author.affiliations[0].name == "Rubin Observatory Project Office"

--- a/tests/storage/authordb_test.py
+++ b/tests/storage/authordb_test.py
@@ -1,0 +1,34 @@
+"""tests for the authordb storage module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from documenteer.storage.authordb import AuthorDb
+
+
+@pytest.fixture
+def author_db_yaml() -> str:
+    """Return the path to a sample authordb.yaml file."""
+    return (
+        Path(__file__).parent.parent / "data" / "authordb.yaml"
+    ).read_text()
+
+
+def test_from_yaml(author_db_yaml: str) -> None:
+    author_db = AuthorDb.from_yaml(author_db_yaml)
+
+    # Assert that the AuthorDb object is created correctly
+    author = author_db.get_author("sickj")
+    assert author.family_name == "Sick"
+    assert author.given_name == "Jonathan"
+    assert author.orcid == "https://orcid.org/0000-0003-3001-676X"
+    assert author.affiliation_id == "RubinObs"
+    assert author.author_id == "sickj"
+    assert (
+        author.affiliation_address
+        == "950 N. Cherry Ave., Tucson, AZ 85719, USA"
+    )
+    assert author.affiliation_name == "Rubin Observatory Project Office"

--- a/tests/storage/technotetoml_test.py
+++ b/tests/storage/technotetoml_test.py
@@ -1,0 +1,57 @@
+"""Tests for the documenteer.stoarge.technotetoml module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+import tomlkit
+
+from documenteer.storage.authordb import AuthorDb
+from documenteer.storage.technotetoml import TechnoteTomlFile
+
+BASIC_TECHNOTE_TOML = """
+[technote]
+title = "A Test Technote"
+"""
+
+
+@pytest.fixture
+def author_db_yaml() -> str:
+    """Return the path to a sample authordb.yaml file."""
+    return (
+        Path(__file__).parent.parent / "data" / "authordb.yaml"
+    ).read_text()
+
+
+def test_append_author(author_db_yaml: str) -> None:
+    author_db = AuthorDb.from_yaml(author_db_yaml)
+
+    # Assert that the AuthorDb object is created correctly
+    author = author_db.get_author("sickj")
+
+    technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
+    technote.upsert_author(author)
+    print(technote.doc)
+
+    authors_aot = technote.authors_aot
+    # a = cast(tomlkit.items.Table, authors_aot[0])
+    a = authors_aot[0]
+    assert cast(str, a["given"]) == "Jonathan"
+    assert cast(str, a["family"]) == "Sick"
+    assert cast(str, a["internal_id"]) == "sickj"
+    assert cast(str, a["orcid"]) == "https://orcid.org/0000-0003-3001-676X"
+    affiliations_aot = cast(tomlkit.items.AoT, a["affiliations"])
+    assert cast(str, affiliations_aot[0]["internal_id"]) == "RubinObs"
+
+    # Modify that author and re-append. It should be modified since author_id
+    # matches
+    author.given_name = "Jon"
+    technote.upsert_author(author)
+    assert cast(str, authors_aot[0]["given"]) == "Jon"
+
+    # Append a different author
+    author2 = author_db.get_author("economouf")
+    technote.upsert_author(author2)
+    assert cast(str, authors_aot[1]["given"]) == "Frossie"

--- a/tests/storage/technotetoml_test.py
+++ b/tests/storage/technotetoml_test.py
@@ -38,8 +38,9 @@ def test_append_author(author_db_yaml: str) -> None:
     authors_aot = technote.authors_aot
     # a = cast(tomlkit.items.Table, authors_aot[0])
     a = authors_aot[0]
-    assert cast(str, a["given"]) == "Jonathan"
-    assert cast(str, a["family"]) == "Sick"
+    name = cast(tomlkit.items.Table, a["name"])
+    assert cast(str, name["given"]) == "Jonathan"
+    assert cast(str, name["family"]) == "Sick"
     assert cast(str, a["internal_id"]) == "sickj"
     assert cast(str, a["orcid"]) == "https://orcid.org/0000-0003-3001-676X"
     affiliations_aot = cast(tomlkit.items.AoT, a["affiliations"])
@@ -49,9 +50,11 @@ def test_append_author(author_db_yaml: str) -> None:
     # matches
     author.given_name = "Jon"
     technote.upsert_author(author)
-    assert cast(str, authors_aot[0]["given"]) == "Jon"
+    name = cast(tomlkit.items.Table, authors_aot[0]["name"])
+    assert cast(str, name["given"]) == "Jon"
 
     # Append a different author
     author2 = author_db.get_author("economouf")
     technote.upsert_author(author2)
-    assert cast(str, authors_aot[1]["given"]) == "Frossie"
+    name = cast(tomlkit.items.Table, authors_aot[1]["name"])
+    assert cast(str, name["given"]) == "Frossie"


### PR DESCRIPTION
- New command-line interface for technote authors.

  - `documenteer technote migrate` automates to the process of migrating an old technote to the new format.
  - `documenteer technote add-author` adds an author to a technote's `technote.toml` file using data from the `authordb.yaml` file in https://github.com/lsst/lsst-texmf.
  - `documenteer technote sync-authors` refreshing author information in a `technote.toml` file with information from the `authordb.yaml` file. This requires that individual authors have `internal_id` fields to correlate with `authordb.yaml`.

The motivation for adding the `add-author` and `sync-authors` commands is to help technote authors use information from lsst-texmf's authordb.yaml file to populate author information in technote.toml. Using these commands ensures that affiliations are consistent and that the `internal_id` is used to correlate authors within Rubin documentation.