### PR TITLE
Update to technote 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-1.1.0'></a>
+## 1.1.0 (2024-01-30)
+
+### New features
+
+- Update to Technote 0.7.0.
+- Add `sphinx_design` as a default extension for technotes.
+
+### Bug fixes
+
+- If the `version` field in `documenteer.toml` isn't set, and the project isn't a Python package, then the default value is now "Latest." The former default, None, was invalid.
+
 <a id='changelog-1.0.1'></a>
 ## 1.0.1 (2024-01-02)
 

--- a/changelog.d/20240130_174434_jsick_DM_42705.md
+++ b/changelog.d/20240130_174434_jsick_DM_42705.md
@@ -1,0 +1,8 @@
+### New features
+
+- Update to Technote 0.7.0.
+- Add `sphinx_design` as a default extension for technotes.
+
+### Bug fixes
+
+- If the `version` field in `documenteer.toml` isn't set, and the project isn't a Python package, then the default value is now "Latest." The former default, None, was invalid.

--- a/changelog.d/20240130_174434_jsick_DM_42705.md
+++ b/changelog.d/20240130_174434_jsick_DM_42705.md
@@ -1,8 +1,0 @@
-### New features
-
-- Update to Technote 0.7.0.
-- Add `sphinx_design` as a default extension for technotes.
-
-### Bug fixes
-
-- If the `version` field in `documenteer.toml` isn't set, and the project isn't a Python package, then the default value is now "Latest." The former default, None, was invalid.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ pipelines = [
 ]
 technote = [
     # Theme and extensions for technotes
-    "technote>=0.6.0,<0.7.0",
+    "technote>=0.7.0,<0.8.0",
     "sphinx-prompt",
     "sphinxcontrib-mermaid",
     "sphinx-diagrams",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ technote = [
     "sphinx-prompt",
     "sphinxcontrib-mermaid",
     "sphinx-diagrams",
+    "sphinx_design",
 ]
 
 [project.urls]

--- a/src/documenteer/conf/_toml.py
+++ b/src/documenteer/conf/_toml.py
@@ -381,7 +381,7 @@ class DocumenteerConfig:
 
         1. project.version field in ``documenteer.toml``
         2. From importlib if the project.python table is set
-        3. Default is None.
+        3. Default is "Latest".
         """
         if self.conf.project.version is not None:
             return self.conf.project.version
@@ -389,7 +389,7 @@ class DocumenteerConfig:
             # Via pydantic validation we know this works
             return get_version(self.conf.project.python.package)
         else:
-            return None
+            return "Latest"
 
     @property
     def rst_epilog_path(self) -> Optional[Path]:

--- a/src/documenteer/conf/technote.py
+++ b/src/documenteer/conf/technote.py
@@ -31,6 +31,7 @@ extensions.extend(  # noqa: F405
         "sphinx_diagrams",
         "sphinxcontrib.mermaid",
         "sphinx_prompt",
+        "sphinx_design",
     ]
 )
 


### PR DESCRIPTION
This version of technote defaults the `date_modified` metadata to the build time if a date isn't explicitly set. Also improves the CSS for code samples.

Additional cahgnes in documenteer:

- Add `sphinx_design` as a default extension for technotes.
- If the `version` field in `documenteer.toml` isn't set, and the project isn't a Python package, then the default value is now "Latest." The former default, None, was invalid.

