### PR TITLE
DM-42967: Add setuptools as a dependency

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -16,16 +16,17 @@ jobs:
       matrix:
         python-version:
           - "3.11"
+          - "3.12"
         sphinx-version:
           - "7"
           - "dev"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -51,14 +52,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           tox-envs: "docs,docs-lint"
           use-cache: false
 
@@ -66,11 +67,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
 
@@ -88,5 +89,5 @@ jobs:
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           upload: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,15 +19,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest
@@ -36,15 +36,16 @@ jobs:
       matrix:
         python-version:
           - '3.11'
+          - '3.12'
         sphinx-version:
           - '7'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
@@ -80,7 +81,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           tox-envs: 'docs,docs-lint'
 
       # Only attempt documentation uploads for tagged releases and pull
@@ -102,14 +103,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           upload: "false"
 
   pypi-publish:
@@ -124,11 +125,11 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
@@ -141,4 +142,4 @@ jobs:
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
-          python-version: '3.11'
+          python-version: '3.12'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run neophile
         uses: lsst-sqre/run-neophile@v1
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           mode: pr
           types: pre-commit
           app-id: ${{ secrets.NEOPHILE_APP_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-1.1.1'></a>
+## 1.1.1 (2024-02-21)
+
+### Bug fixes
+
+- `setuptools` is now included in the core package dependencies. The `documenteer.ext.bibtex` extension uses `pybtex`, which is turn uses `pkg_resources` from `setuptools`. In Python 3.12, setuptools is not available in Python environments by default. This direct dependency can be removed once `pybtex` is updated to use `importlib.metadata`.
+
+### Other changes
+
+- Update to the Python project configuration guide for `documenteer.toml` to use an example project other than "Documenteer" in the examples. Also emphasize the requirement that the project must be installed to use the `[project.python]` configuration in `documenteer.toml`.
+
 <a id='changelog-1.1.0'></a>
 ## 1.1.0 (2024-01-30)
 

--- a/changelog.d/20240213_094921_jsick_guide_examples.md
+++ b/changelog.d/20240213_094921_jsick_guide_examples.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Update to the Python project configuration guide for `documenteer.toml` to use an example project other than "Documenteer" in the examples. Also emphasize the requirement that the project must be installed to use the `[project.python]` configuration in `documenteer.toml`.

--- a/changelog.d/20240221_130347_jsick_DM_42967.md
+++ b/changelog.d/20240221_130347_jsick_DM_42967.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- `setuptools` is now included in the core package dependencies. The `documenteer.ext.bibtex` extension uses `pybtex`, which is turn uses `pkg_resources` from `setuptools`. In Python 3.12, setuptools is not available in Python environments by default. This direct dependency can be removed once `pybtex` is updated to use `importlib.metadata`.

--- a/changelog.d/20240221_130347_jsick_DM_42967.md
+++ b/changelog.d/20240221_130347_jsick_DM_42967.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- `setuptools` is now included in the core package dependencies. The `documenteer.ext.bibtex` extension uses `pybtex`, which is turn uses `pkg_resources` from `setuptools`. In Python 3.12, setuptools is not available in Python environments by default. This direct dependency can be removed once `pybtex` is updated to use `importlib.metadata`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "requests",
     "click",
     "sphinxcontrib-bibtex>=2.0.0", # for pybtex extension
+    "setuptools", # for pkg_resources, used by pybtex
     "pydantic >= 2.0.0",
     "urllib3",
     "pylatexenc",


### PR DESCRIPTION
This is required by pybtex, which is used by documenteer.ext.bibtex. Ideally pybtex will switch to importlib.metadata so that this dependency will no longer be required.