### PR TITLE
DM-43638: Update to technote 0.8 to fix baseline alignment for monospace text in technotes

### DIFF
--- a/changelog.d/20240502_153501_jsick_DM_43638.md
+++ b/changelog.d/20240502_153501_jsick_DM_43638.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fixed the monospace text baseline alignment issue in Safari for technotes by updating to technote 0.8.0. In this version, the font size of the code is set to be 0.9em so that the browser doesn't push the text below the baseline in case its larger than the Source Sans body text. This version also changes the font size on the html element to 100% and instead increases the baseline body text size to 1.1rem on the body element. This change should help technotes respect the user's browser font size settings while also making the rem unit work as expected.

--- a/demo/rst-technote/index.rst
+++ b/demo/rst-technote/index.rst
@@ -16,7 +16,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin facilisis pharetr
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin facilisis pharetra neque, at semper nulla mattis auctor. Proin semper mollis enim eget interdum. Mauris eleifend eget diam vitae bibendum. Praesent ut aliquet odio, sodales imperdiet nisi. Nam interdum imperdiet tortor sed fringilla. Maecenas efficitur mi sodales nulla commodo rutrum. Ut ornare diam quam, sed commodo turpis aliquam et. In nec enim consequat, suscipit tortor sit amet, luctus ante. Integer dictum augue diam, non pulvinar massa euismod in. Morbi viverra condimentum auctor. Nullam et metus mauris. Cras risus ex, porta sit amet nibh et, dapibus auctor leo.
 
-A parenthetical citation :cite:p:`SQR-083`. And a textual citation :cite:t:`SQR-083`.
+A parenthetical citation :cite:p:`SQR-083`. And a textual citation :cite:t:`SQR-083`. Some ``source code`` embedded in text.
 
 Method
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ pipelines = [
 ]
 technote = [
     # Theme and extensions for technotes
-    "technote>=0.7.0,<0.8.0",
+    "technote>=0.8.0,<0.9.0",
     "sphinx-prompt",
     "sphinxcontrib-mermaid",
     "sphinx-diagrams",

--- a/src/assets/rubin-technote/styles/components/_article-header.scss
+++ b/src/assets/rubin-technote/styles/components/_article-header.scss
@@ -5,7 +5,7 @@
   max-width: 12rem;
 }
 
-@media (max-width: 76rem) {
+@media (max-width: 76em) {
   // When the primary sidebar is hidden, remove extra top margin from the
   // container so the logo is closer to the top.
   .sb-container {
@@ -13,7 +13,7 @@
   }
 }
 
-@media (min-width: 76rem) {
+@media (min-width: 76em) {
   // Hide the mobile logo when the primary sidebar is visible.
   .mobile-rubin-technote-logo {
     display: none;

--- a/src/assets/rubin-technote/styles/components/_authors.scss
+++ b/src/assets/rubin-technote/styles/components/_authors.scss
@@ -3,6 +3,6 @@
  */
 
 .technote-inline-authors {
-  font-size: 1.1rem;
+  font-size: 1.1em;
   font-weight: 425;
 }


### PR DESCRIPTION
This change fixes the baseline misalignment for monospace text in technotes.