### PR TITLE
DM-46777: sphinx < 8.1.0

### DIFF
--- a/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
+++ b/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Pin `sphinx` to < 8.1.0. [Sphinx 8.1.0](https://github.com/sphinx-doc/sphinx/compare/v8.0.2...v8.1.0) contains [a commit](https://github.com/sphinx-doc/sphinx/pull/12762/files#diff-a4c6bf1492ef480b94af82c988f64ca56fa256fab0ed043a5ad3d4043f89a645L14) that removes the `ExtensionError` export from the `sphinx.util` package. This currently breaks the [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) dependency.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
     "docutils>=0.20",  # solves an extra div bug with the bibliography directive
-    "Sphinx>=7",  # Consistent docutils constraint
+    "Sphinx>=7,<8.1.0",  # Consistent docutils constraint, mermaid compatibility
     "PyYAML",
     "GitPython",
     "requests",


### PR DESCRIPTION
[Sphinx 8.1.0](https://github.com/sphinx-doc/sphinx/compare/v8.0.2...v8.1.0) contains [a commit](https://github.com/sphinx-doc/sphinx/pull/12762/files#diff-a4c6bf1492ef480b94af82c988f64ca56fa256fab0ed043a5ad3d4043f89a645L14) that removes the `ExtensionError` export from the `sphinx.util` package. This currently breaks the [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) dependency:

```
  File "/home/danfuchs/src/safir/.nox/docs-clean/lib/python3.12/site-packages/sphinxcontrib/autoclassdiag.py", line 3, in <module>
    from sphinx.util import ExtensionError, import_object
ImportError: cannot import name 'ExtensionError' from 'sphinx.util' (/home/danfuchs/src/safir/.nox/docs-clean/lib/python3.12/site-packages/sphinx/util/__init__.py)
```

Pin to < 8.1.0 for now until this gets fixed in either `sphinx` or `sphinxcontrib-mermaid` (and any other packages that we use that might also be broken).
