### PR TITLE
DM-46777: sphinx < 8.1.0

### DIFF
--- a/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
+++ b/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Pin `sphinx` to < 8.1.0. [Sphinx 8.1.0](https://github.com/sphinx-doc/sphinx/compare/v8.0.2...v8.1.0) contains [a commit](https://github.com/sphinx-doc/sphinx/pull/12762/files#diff-a4c6bf1492ef480b94af82c988f64ca56fa256fab0ed043a5ad3d4043f89a645L14) that removes the `ExtensionError` export from the `sphinx.util` package. This currently breaks the [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) dependency.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
     "docutils>=0.20",  # solves an extra div bug with the bibliography directive
-    "Sphinx>=7",  # Consistent docutils constraint
+    "Sphinx>=7,<8.1.0",  # Consistent docutils constraint, mermaid compatibility
     "PyYAML",
     "GitPython",
     "requests",

--- a/src/documenteer/stackdocs/doxygen.py
+++ b/src/documenteer/stackdocs/doxygen.py
@@ -333,7 +333,11 @@ class DoxygenConfiguration:
                 self._render_path_list(lines, tag_name, value)
             elif tag_field.type == List[str]:
                 self._render_str_list(lines, tag_name, value)
-            elif tag_field.type == Path or tag_field.type == Optional[Path]:
+            elif (
+                tag_field.type == Path
+                or tag_field.type
+                == Optional[Path]  # type: ignore[comparison-overlap]
+            ):
                 self._render_path(lines, tag_name, value)
         return "\n".join(lines) + "\n"
 


### PR DESCRIPTION
* Backport of https://github.com/lsst-sqre/documenteer/pull/230
* Ignore type checking for one line that has a type error that gets caught by a newer version of mypy.  This file is removed on main, so I don't want to change anything, at least in the PR.