### PR TITLE
DM-46777: Add a lower bound on sphinxcontrib-mermaid, revert sphinx pin

### DIFF
--- a/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
+++ b/changelog.d/20241010_133336_danfuchs_mermaid_compat.md
@@ -1,4 +1,4 @@
 ### Bug fixes
 
-- Pin `sphinx` to < 8.1.0. [Sphinx 8.1.0](https://github.com/sphinx-doc/sphinx/compare/v8.0.2...v8.1.0) contains [a commit](https://github.com/sphinx-doc/sphinx/pull/12762/files#diff-a4c6bf1492ef480b94af82c988f64ca56fa256fab0ed043a5ad3d4043f89a645L14) that removes the `ExtensionError` export from the `sphinx.util` package. This currently breaks the [sphinxcontrib-mermaid](https://github.com/mgaitan/sphinxcontrib-mermaid) dependency.
+- Bump `sphinxcontrib-mermaid` to >= 1, which fixes an incompatibility with sphinx==1.8.1, and allows us to unpin the version of mermaid JS.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
     "docutils>=0.20",  # solves an extra div bug with the bibliography directive
-    "Sphinx>=7,<8.1.0",  # Consistent docutils constraint, mermaid compatibility
+    "Sphinx>=7",  # Consistent docutils constraint
     "PyYAML",
     "GitPython",
     "requests",
@@ -74,7 +74,7 @@ guide = [
     "myst-parser",
     "myst-nb",
     "markdown-it-py[linkify]",
-    "sphinxcontrib-mermaid",
+    "sphinxcontrib-mermaid>=1",
     "sphinxext-opengraph",
     "sphinxcontrib-redoc",
     "sphinxcontrib-jquery",

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -103,7 +103,6 @@ __all__ = [
     "myst_enable_extensions",
     # MERMAID
     "mermaid_output_format",
-    "mermaid_version",
     # OPENGRAPH
     "ogp_site_url",
     "ogp_site_name",
@@ -438,10 +437,6 @@ myst_enable_extensions = [
 # The raw format renders the diagram client-side, and doesn't require a
 # Mermaid CLI installation
 mermaid_output_format = "raw"
-
-# Temporary workaround for not getting mermaid 10 successfully from unpkg
-# https://github.com/mgaitan/sphinxcontrib-mermaid/issues/110
-mermaid_version = "9.4.0"
 
 # ============================================================================
 # #OPENGRAPH OpenGraph diagram support

--- a/src/documenteer/ext/remotecodeblock.py
+++ b/src/documenteer/ext/remotecodeblock.py
@@ -12,7 +12,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.application import Sphinx
 from sphinx.directives.code import LiteralIncludeReader, container_wrapper
-from sphinx.util import logging, parselinenos
+from sphinx.util import logging, parselinenos  # type: ignore[attr-defined]
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.nodes import set_source_info
 from sphinx.util.typing import ExtensionMetadata


### PR DESCRIPTION
* Set a lower bound on sphinxcontrib-mermaid to <=1
* Revert the Sphinx pin because this fixes the compatibility issue
* Ditch the `mermaid_version` pin because this fixes https://github.com/mgaitan/sphinxcontrib-mermaid/issues/110
* Ignore an import that mypy 1.12 doesn't consider re-exported anymore (it's renamed with `as`, not sure if that's a mypy bug, or if those are the real rules and it's a mypy fix)

Tested:
* Phalanx docs build
* [DMTN-234](https://dmtn-234.lsst.io/#tokens) build