### PR TITLE
DM-48755: Point to Squarebot in rubin-obs Slack in technote documentation

### DIFF
--- a/changelog.d/20250203_175511_jsick_DM_48755.md
+++ b/changelog.d/20250203_175511_jsick_DM_48755.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Point to `@Squarebot` in the rubin-obs Slack in the documentation for creating a technote.

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -63,7 +63,7 @@
 .. _pipx: https://pipx.pypa.io
 .. _`LSSTC Slack Workspace`: https://lsstc.slack.com
 
-.. |dmw-sqrbot| replace:: `direct message with @sqrbot-jr <https://slack.com/app_redirect?app=AF2U6ADV3&team=T06D204F2>`__
+.. |dmw-squarebot| replace:: `direct message with @squarebot <https://rubin-obs.slack.com/archives/D07QDJW6VEY>`__
 
 .. Internal links
 

--- a/docs/technotes/start-a-technote.rst
+++ b/docs/technotes/start-a-technote.rst
@@ -15,7 +15,7 @@ If you don't have push access in a whole organization, you can alternatively ask
 Create a technote repository through Slack
 ==========================================
 
-1. In Slack, open a |dmw-sqrbot| and type:
+1. In Slack, open a |dmw-squarebot| and type:
 
 .. code-block:: text
 


### PR DESCRIPTION
We've turned off the orginal sqrbot-jr in the former LSSTC workspace. Squarebot is the bot going forwards.