### PR TITLE
DM-49037: Run Prettier directly from tox / update test configurations / Pin Sphinx < 8.2

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -44,6 +44,17 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: 'lint'
           use-cache: false
+
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic lint for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
   test:
     runs-on: ubuntu-latest
 
@@ -90,6 +101,16 @@ jobs:
           tox-envs: "typing-sphinx${{ matrix.sphinx-version }},py-test-sphinx${{ matrix.sphinx-version }},demo"
           use-cache: false
 
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
   docs:
     runs-on: ubuntu-latest
 
@@ -104,6 +125,16 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "docs,docs-lint"
           use-cache: false
+
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic documentation test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
 
   pypi:
     runs-on: ubuntu-latest
@@ -133,3 +164,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           upload: false
+
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic packaging test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -52,6 +52,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
         sphinx-version:
           - "7"
           - "8"

--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -12,6 +12,38 @@ env:
     - cron: "0 12 * * 1"
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          tox-envs: 'lint'
+          use-cache: false
   test:
     runs-on: ubuntu-latest
 
@@ -54,7 +86,7 @@ jobs:
         uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python-version }}
-          tox-envs: "lint,typing-sphinx${{ matrix.sphinx-version }},py-test-sphinx${{ matrix.sphinx-version }},demo"
+          tox-envs: "typing-sphinx${{ matrix.sphinx-version }},py-test-sphinx${{ matrix.sphinx-version }},demo"
           use-cache: false
 
   docs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,7 @@ jobs:
         python-version:
           - '3.11'
           - '3.12'
+          - '3.13'
         sphinx-version:
           - '7'
           - '8'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,29 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          tox-envs: 'lint'
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,9 +27,3 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==24.4.2]
         args: [-l, '79', -t, py312]
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types_or: [css, scss, javascript]

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,8 @@ demo/
 .tox
 *.md
 **/*.md
+**/*.yml
+**/*.yaml
 src/documenteer/templates/**/*.html
 src/documenteer/assets/static/styles
 src/documenteer/assets/static/scripts

--- a/changelog.d/20250219_160628_jsick_DM_49037.md
+++ b/changelog.d/20250219_160628_jsick_DM_49037.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+-
+
+### Bug fixes
+
+-
+
+### Other changes
+
+- Drop use of the pre-commit hook for prettier, and instead run prettier directly from the tox lint environment. This change is necessary because the prettier hook for pre-commit is no longer supported.

--- a/changelog.d/20250219_160628_jsick_DM_49037.md
+++ b/changelog.d/20250219_160628_jsick_DM_49037.md
@@ -15,3 +15,5 @@
 ### Other changes
 
 - Drop use of the pre-commit hook for prettier, and instead run prettier directly from the tox lint environment. This change is necessary because the prettier hook for pre-commit is no longer supported.
+
+- Add Python 3.13 to the test matrix.

--- a/changelog.d/20250219_160628_jsick_DM_49037.md
+++ b/changelog.d/20250219_160628_jsick_DM_49037.md
@@ -10,7 +10,7 @@
 
 ### Bug fixes
 
--
+- Pin Sphinx < 8.2 to avoid a bug/incompatibility with the `sphinxcontrib-bibtex` extension.
 
 ### Other changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "mini-css-extract-plugin": "^2.4.4",
         "normalize.css": "^8.0.1",
         "postcss-loader": "^6.2.0",
+        "prettier": "3.5.1",
         "sass": "^1.53.0",
         "sass-loader": "^12.3.0",
         "style-loader": "^3.3.1",
@@ -2469,6 +2470,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -5028,6 +5044,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "mini-css-extract-plugin": "^2.4.4",
     "normalize.css": "^8.0.1",
     "postcss-loader": "^6.2.0",
+    "prettier": "3.5.1",
     "sass": "^1.53.0",
     "sass-loader": "^12.3.0",
     "style-loader": "^3.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Documentation",
     "Topic :: Documentation :: Sphinx",
     "Typing :: Typed",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 dependencies = [
     "docutils>=0.20",  # solves an extra div bug with the bibliography directive
-    "Sphinx>=7",  # Consistent docutils constraint
+    "Sphinx>=7,<8.2",  # Consistent docutils constraint
     "PyYAML",
     "GitPython",
     "requests",

--- a/src/assets/rubin-technote/styles/_properties.scss
+++ b/src/assets/rubin-technote/styles/_properties.scss
@@ -19,9 +19,9 @@
 }
 
 :root {
-  --tn-component-text-font-family: 'Source Sans 3 VF', -apple-system,
-    BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans,
-    Droid Sans, Helvetica Neue, sans-serif;
+  --tn-component-text-font-family:
+    'Source Sans 3 VF', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+    Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
   --tn-component-text-color: var(--rsd-component-text-color);
   --tn-component-toc-header-color: var(--rsd-color-primary-600);
   --tn-component-sidebar-header-color: var(--rsd-color-primary-600);

--- a/src/documenteer/assets/rubin-pydata-theme.css
+++ b/src/documenteer/assets/rubin-pydata-theme.css
@@ -67,8 +67,8 @@ html[data-theme='dark'] {
 
 :root {
   --pst-font-family-base: 'Source Sans Pro', var(--pst-font-family-base-system);
-  --pst-font-family-heading: 'Source Sans Pro',
-    var(--pst-font-family-base-system);
+  --pst-font-family-heading:
+    'Source Sans Pro', var(--pst-font-family-base-system);
 
   /* Base font size; increased for pydata-sphinx-theme default. */
   font-size: 18px;

--- a/tox.ini
+++ b/tox.ini
@@ -40,9 +40,13 @@ commands =
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).
 skip_install = true
+allowlist_externals =
+    npx
 deps =
     pre-commit
-commands = pre-commit run --all-files
+commands =
+    pre-commit run --all-files
+    npx prettier '**/*.{css,scss,js}' --write
 
 [testenv:typing-sphinx{7,8,dev}]
 description = Run mypy.


### PR DESCRIPTION
Transition from using a pre-commit hook for Prettier to running it directly within the Tox lint environment due to lack of support. Update the test matrix to include Python 3.13 and implement Slack notifications for cron test failures. Pin Sphinx to a version below 8.2 to avoid compatibility issues with the `sphinxcontrib-bibtex` extension. Reformat files with Prettier 3.5.1.