### PR TITLE
Ensure graphviz is installed in GitHub Actions

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -89,10 +89,8 @@ jobs:
           npm install
           npm run build
 
-      - name: Install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install graphviz
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
 
       - name: Run tests in tox
         uses: lsst-sqre/run-tox@v1
@@ -118,6 +116,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
 
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1

--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -117,6 +117,22 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,10 +85,8 @@ jobs:
           npm install
           npm run build
 
-      - name: Install graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install graphviz
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
 
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
@@ -104,8 +102,8 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Install Graphviz
-        run: sudo apt-get install graphviz
+      - name: Setup Graphviz
+        uses: ts-graphviz/setup-graphviz@v2
 
       - name: Run tox
         uses: lsst-sqre/run-tox@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,22 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
 
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
@@ -134,6 +150,22 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build
+
       - name: Build and publish
         uses: lsst-sqre/build-and-publish-to-pypi@v2
         with:
@@ -160,6 +192,12 @@ jobs:
         with:
           cache: 'npm'
           node-version-file: '.nvmrc'
+
+      - name: Authenticate GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NPM_PKG_TOKEN}" > ~/.npmrc
+        env:
+          NPM_PKG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: npm install and build
         run: |

--- a/changelog.d/20250224_102742_jsick_graphviz_ci.md
+++ b/changelog.d/20250224_102742_jsick_graphviz_ci.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+-
+
+### Bug fixes
+
+-
+
+### Other changes
+
+- Adopt [ts-graphviz/setup-graphviz](https://github.com/ts-graphviz/setup-graphviz) for installing Graphviz in GitHub Actions CI workflows.


### PR DESCRIPTION
- Use ts-graphviz/setup-graphviz for setup graphviz, needed for docs builds
- Ensure that the full CSS and JS assets are built in more environments. For example, ensure they're available for documentation builds.