### PR TITLE
Allow ci-cron to start via workflow_dispatch

### DIFF
--- a/.github/workflows/ci-cron.yaml
+++ b/.github/workflows/ci-cron.yaml
@@ -10,6 +10,7 @@ env:
 "on":
   schedule:
     - cron: "0 12 * * 1"
+  workflow_dispatch: {}
 
 jobs:
   lint:


### PR DESCRIPTION
Enables manual starts of the periodic CI workflow.