### PR TITLE
DM-51727: Adopt the Ook API for getting author information

### DIFF
--- a/changelog.d/20250710_133037_jsick_DM_51727.md
+++ b/changelog.d/20250710_133037_jsick_DM_51727.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+- The `documenteer` `add-authors` and `sync-authors` CLI commands now uses the Ook web API to get author information, rather than directly reading `authordb.yaml` from lsst/lsst-texmf.
+
+### Bug fixes
+
+-
+
+### Other changes
+
+-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "coverage[toml]",
     "pytest",
     "pytest-mock",
+    "pytest-responses",
     # Test depedendencies for analyzing HTML output
     "lxml",
     "cssselect",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,9 +222,6 @@ extend-ignore = [
     "INP001",
     "D100"
 ]
-"src/documenteer/cli.py" = [
-    "T201",  # CLI scripts can print
-]
 
 [tool.ruff.lint.isort]
 known-first-party = ["documenteer", "tests"]

--- a/src/documenteer/cli.py
+++ b/src/documenteer/cli.py
@@ -97,7 +97,7 @@ def technote_add_author(author_id: str, technote_toml: str) -> None:
     """
     toml_path = Path(technote_toml)
     toml_file = TechnoteTomlFile.open(toml_path)
-    author_db = AuthorDb.download()
+    author_db = AuthorDb()
 
     service = TechnoteAuthorService(toml_file, author_db)
     author = service.add_author_by_id(author_id)
@@ -120,7 +120,7 @@ def technote_sync_authors(technote_toml: str) -> None:
     """Sync author info from authordb.yaml to technote.toml."""
     toml_path = Path(technote_toml)
     toml_file = TechnoteTomlFile.open(toml_path)
-    author_db = AuthorDb.download()
+    author_db = AuthorDb()
 
     service = TechnoteAuthorService(toml_file, author_db)
     updated_authors = service.sync_authors()
@@ -132,7 +132,10 @@ def technote_sync_authors(technote_toml: str) -> None:
     else:
         print(f"Synchronized authors to {toml_path}:")
         for a in updated_authors:
-            print(f"- {a.given_name} {a.family_name} ({a.author_id})")
+            print(
+                f"- {a.given_name if a.given_name else ''} {a.family_name} "
+                f"({a.internal_id})"
+            )
 
 
 @technote.command(name="migrate")
@@ -177,7 +180,7 @@ def technote_migrate(
     The `-a/--author-id` options are author IDs in the Rubin author database.
     See https://github.com/lsst/lsst-texmf/blob/main/etc/authordb.yaml
     """
-    author_db = AuthorDb.download()
+    author_db = AuthorDb()
     migration_service = TechnoteMigrationService(Path(root_dir), author_db)
     migration_service.migrate(author_ids=author_ids)
 

--- a/src/documenteer/cli.py
+++ b/src/documenteer/cli.py
@@ -101,7 +101,7 @@ def technote_add_author(author_id: str, technote_toml: str) -> None:
 
     service = TechnoteAuthorService(toml_file, author_db)
     author = service.add_author_by_id(author_id)
-    print(
+    click.echo(
         f"Added author {author.given_name} {author.family_name} to {toml_path}"
     )
     service.write_toml(toml_path)
@@ -127,12 +127,12 @@ def technote_sync_authors(technote_toml: str) -> None:
     service.write_toml(toml_path)
 
     if len(updated_authors) == 0:
-        print("No authors to update")
+        click.echo("No authors to update")
         return
     else:
-        print(f"Synchronized authors to {toml_path}:")
+        click.echo(f"Synchronized authors to {toml_path}:")
         for a in updated_authors:
-            print(
+            click.echo(
                 f"- {a.given_name if a.given_name else ''} {a.family_name} "
                 f"({a.internal_id})"
             )

--- a/src/documenteer/services/technoteauthor.py
+++ b/src/documenteer/services/technoteauthor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from documenteer.storage.authordb import AuthorDb, AuthorInfo
+from documenteer.storage.authordb import Author, AuthorDb
 from documenteer.storage.technotetoml import TechnoteTomlFile
 
 
@@ -21,31 +21,21 @@ class TechnoteAuthorService:
         """Write the technote.toml file."""
         self.toml_file.save(path)
 
-    def add_author_by_id(self, author_id: str) -> AuthorInfo:
+    def add_author_by_id(self, author_id: str) -> Author:
         """Add an author to the technote.toml file."""
-        try:
-            author = self.author_db.get_author(author_id)
-        except KeyError as e:
-            raise ValueError(
-                f"Author {author_id} not found in authordb.yaml"
-            ) from e
+        author = self.author_db.get_author(author_id)
 
         self.toml_file.upsert_author(author)
 
         return author
 
-    def sync_authors(self) -> list[AuthorInfo]:
+    def sync_authors(self) -> list[Author]:
         """Synchronize author info from authordb.yaml."""
-        updated_authors: list[AuthorInfo] = []
+        updated_authors: list[Author] = []
 
         for author_id in self.toml_file.author_ids:
-            try:
-                author = self.author_db.get_author(author_id)
-                updated_authors.append(author)
-            except KeyError as e:
-                raise ValueError(
-                    f"Author {author_id} not found in authordb.yaml"
-                ) from e
+            author = self.author_db.get_author(author_id)
+            updated_authors.append(author)
             self.toml_file.upsert_author(author)
 
         return updated_authors

--- a/tests/services/technotemigration_test.py
+++ b/tests/services/technotemigration_test.py
@@ -97,13 +97,8 @@ Hello
 
     toml_path = tmp_path / "technote.toml"
     assert toml_path.exists()
-    print(toml_path.read_text())
 
     toml_file = TechnoteTomlFile.open(toml_path)
-    assert cast(str, toml_file.technote_table["id"]) == "SQR-065"
-    assert cast(str, toml_file.technote_table["series_id"]) == "SQR"
+    assert cast("str", toml_file.technote_table["id"]) == "SQR-065"
+    assert cast("str", toml_file.technote_table["series_id"]) == "SQR"
     assert toml_file.author_ids == ["sickj"]
-
-    print(content_path.read_text())
-
-    # assert False

--- a/tests/services/technotemigration_test.py
+++ b/tests/services/technotemigration_test.py
@@ -5,24 +5,60 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
-import pytest
+import pytest_responses  # noqa: F401
 import yaml
+from responses import RequestsMock
 
 from documenteer.services.technotemigration import TechnoteMigrationService
 from documenteer.storage.authordb import AuthorDb
 from documenteer.storage.technotetoml import TechnoteTomlFile
 
 
-@pytest.fixture
-def author_db_yaml() -> str:
-    """Return the path to a sample authordb.yaml file."""
-    return (
-        Path(__file__).parent.parent / "data" / "authordb.yaml"
-    ).read_text()
-
-
-def test_migration(tmp_path: Path, author_db_yaml: str) -> None:
+def test_migration(tmp_path: Path, responses: RequestsMock) -> None:
     """Test migrating a technote."""
+    response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Ontario",
+                "country": "Canada",
+                "postal_code": null,
+                "state": null,
+                "street": "Penetanguishene"
+            },
+            "department": null,
+            "internal_id": "JSickCodes",
+            "name": "J.Sick Codes Inc.",
+            "ror": null
+        },
+        {
+            "address": {
+                "city": "Tucson",
+                "country": "USA",
+                "postal_code": "85719",
+                "state": "AZ",
+                "street": "950 N. Cherry Ave."
+            },
+            "department": null,
+            "internal_id": "RubinObs",
+            "name": "Vera C. Rubin Observatory Project Office",
+            "ror": "https://ror.org/048g3cy84"
+        }
+    ],
+    "family_name": "Sick",
+    "given_name": "Jonathan",
+    "internal_id": "sickj",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0003-3001-676X"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/sickj",
+        body=response_data,
+        content_type="application/json",
+        status=200,
+    )
     metadata = {
         "series": "SQR",
         "serial_number": "065",
@@ -55,7 +91,7 @@ Hello
     content_path = tmp_path / "index.rst"
     content_path.write_text(content)
 
-    author_db = AuthorDb.from_yaml(author_db_yaml)
+    author_db = AuthorDb()
     service = TechnoteMigrationService(tmp_path, author_db)
     service.migrate(author_ids=["sickj"])
 

--- a/tests/storage/authordb_test.py
+++ b/tests/storage/authordb_test.py
@@ -2,33 +2,64 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
+import pytest_responses  # noqa: F401
+from responses import RequestsMock
 
 from documenteer.storage.authordb import AuthorDb
 
 
-@pytest.fixture
-def author_db_yaml() -> str:
-    """Return the path to a sample authordb.yaml file."""
-    return (
-        Path(__file__).parent.parent / "data" / "authordb.yaml"
-    ).read_text()
-
-
-def test_from_yaml(author_db_yaml: str) -> None:
-    author_db = AuthorDb.from_yaml(author_db_yaml)
-
+def test_from_yaml(responses: RequestsMock) -> None:
     # Assert that the AuthorDb object is created correctly
+    response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Ontario",
+                "country": "Canada",
+                "postal_code": null,
+                "state": null,
+                "street": "Penetanguishene"
+            },
+            "department": null,
+            "internal_id": "JSickCodes",
+            "name": "J.Sick Codes Inc.",
+            "ror": null
+        },
+        {
+            "address": {
+                "city": "Tucson",
+                "country": "USA",
+                "postal_code": "85719",
+                "state": "AZ",
+                "street": "950 N. Cherry Ave."
+            },
+            "department": null,
+            "internal_id": "RubinObs",
+            "name": "Vera C. Rubin Observatory Project Office",
+            "ror": "https://ror.org/048g3cy84"
+        }
+    ],
+    "family_name": "Sick",
+    "given_name": "Jonathan",
+    "internal_id": "sickj",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0003-3001-676X"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/sickj",
+        body=response_data,
+        content_type="application/json",
+        status=200,
+    )
+
+    author_db = AuthorDb()
     author = author_db.get_author("sickj")
     assert author.family_name == "Sick"
     assert author.given_name == "Jonathan"
-    assert author.author_id == "sickj"
-    assert author.orcid == "https://orcid.org/0000-0003-3001-676X"
-    assert author.affiliations[0].id == "RubinObs"
-    assert (
-        author.affiliations[0].address
-        == "950 N. Cherry Ave., Tucson, AZ 85719, USA"
-    )
-    assert author.affiliations[0].name == "Rubin Observatory Project Office"
+    assert author.internal_id == "sickj"
+    assert str(author.orcid) == "https://orcid.org/0000-0003-3001-676X"
+    assert author.affiliations[0].internal_id == "JSickCodes"
+    assert author.affiliations[0].name == "J.Sick Codes Inc."
+    assert str(author.affiliations[1].ror) == "https://ror.org/048g3cy84"

--- a/tests/storage/technotetoml_test.py
+++ b/tests/storage/technotetoml_test.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import cast
 
-import pytest
+import pytest_responses  # noqa: F401
 import tomlkit
+from responses import RequestsMock
 
 from documenteer.storage.authordb import AuthorDb
 from documenteer.storage.technotetoml import TechnoteTomlFile
@@ -17,18 +17,84 @@ title = "A Test Technote"
 """
 
 
-@pytest.fixture
-def author_db_yaml() -> str:
-    """Return the path to a sample authordb.yaml file."""
-    return (
-        Path(__file__).parent.parent / "data" / "authordb.yaml"
-    ).read_text()
+def test_append_author(responses: RequestsMock) -> None:
+    js_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Ontario",
+                "country": "Canada",
+                "postal_code": null,
+                "state": null,
+                "street": "Penetanguishene"
+            },
+            "department": null,
+            "internal_id": "JSickCodes",
+            "name": "J.Sick Codes Inc.",
+            "ror": null
+        },
+        {
+            "address": {
+                "city": "Tucson",
+                "country": "USA",
+                "postal_code": "85719",
+                "state": "AZ",
+                "street": "950 N. Cherry Ave."
+            },
+            "department": null,
+            "internal_id": "RubinObs",
+            "name": "Vera C. Rubin Observatory Project Office",
+            "ror": "https://ror.org/048g3cy84"
+        }
+    ],
+    "family_name": "Sick",
+    "given_name": "Jonathan",
+    "internal_id": "sickj",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0003-3001-676X"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/sickj",
+        body=js_response_data,
+        content_type="application/json",
+        status=200,
+    )
 
-
-def test_append_author(author_db_yaml: str) -> None:
-    author_db = AuthorDb.from_yaml(author_db_yaml)
+    fe_response_data = """
+{
+    "affiliations": [
+        {
+            "address": {
+                "city": "Tucson",
+                "country": "USA",
+                "postal_code": "85719",
+                "state": "AZ",
+                "street": "950 N. Cherry Ave."
+            },
+            "department": null,
+            "internal_id": "RubinObs",
+            "name": "Vera C. Rubin Observatory Project Office",
+            "ror": "https://ror.org/048g3cy84"
+        }
+    ],
+    "family_name": "Economou",
+    "given_name": "Frossie",
+    "internal_id": "economouf",
+    "notes": [],
+    "orcid": "https://orcid.org/0000-0002-8333-7615"
+}
+"""
+    responses.get(
+        "https://roundtable.lsst.cloud/ook/authors/economouf",
+        body=fe_response_data,
+        content_type="application/json",
+        status=200,
+    )
 
     # Assert that the AuthorDb object is created correctly
+    author_db = AuthorDb()
     author = author_db.get_author("sickj")
 
     technote = TechnoteTomlFile(BASIC_TECHNOTE_TOML)
@@ -43,7 +109,7 @@ def test_append_author(author_db_yaml: str) -> None:
     assert cast(str, a["internal_id"]) == "sickj"
     assert cast(str, a["orcid"]) == "https://orcid.org/0000-0003-3001-676X"
     affiliations_aot = cast(tomlkit.items.AoT, a["affiliations"])
-    assert cast(str, affiliations_aot[0]["internal_id"]) == "RubinObs"
+    assert cast(str, affiliations_aot[1]["internal_id"]) == "RubinObs"
 
     # Modify that author and re-append. It should be modified since author_id
     # matches

--- a/tests/storage/technotetoml_test.py
+++ b/tests/storage/technotetoml_test.py
@@ -103,23 +103,23 @@ def test_append_author(responses: RequestsMock) -> None:
 
     authors_aot = technote.authors_aot
     a = authors_aot[0]
-    name = cast(tomlkit.items.Table, a["name"])
-    assert cast(str, name["given"]) == "Jonathan"
-    assert cast(str, name["family"]) == "Sick"
-    assert cast(str, a["internal_id"]) == "sickj"
-    assert cast(str, a["orcid"]) == "https://orcid.org/0000-0003-3001-676X"
-    affiliations_aot = cast(tomlkit.items.AoT, a["affiliations"])
-    assert cast(str, affiliations_aot[1]["internal_id"]) == "RubinObs"
+    name = cast("tomlkit.items.Table", a["name"])
+    assert cast("str", name["given"]) == "Jonathan"
+    assert cast("str", name["family"]) == "Sick"
+    assert cast("str", a["internal_id"]) == "sickj"
+    assert cast("str", a["orcid"]) == "https://orcid.org/0000-0003-3001-676X"
+    affiliations_aot = cast("tomlkit.items.AoT", a["affiliations"])
+    assert cast("str", affiliations_aot[1]["internal_id"]) == "RubinObs"
 
     # Modify that author and re-append. It should be modified since author_id
     # matches
     author.given_name = "Jon"
     technote.upsert_author(author)
-    name = cast(tomlkit.items.Table, authors_aot[0]["name"])
-    assert cast(str, name["given"]) == "Jon"
+    name = cast("tomlkit.items.Table", authors_aot[0]["name"])
+    assert cast("str", name["given"]) == "Jon"
 
     # Append a different author
     author2 = author_db.get_author("economouf")
     technote.upsert_author(author2)
-    name = cast(tomlkit.items.Table, authors_aot[1]["name"])
-    assert cast(str, name["given"]) == "Frossie"
+    name = cast("tomlkit.items.Table", authors_aot[1]["name"])
+    assert cast("str", name["given"]) == "Frossie"


### PR DESCRIPTION
The `documenteer` `add-authors` and `sync-authors` CLI commands now uses the Ook web API to get author information, rather than directly reading `authordb.yaml` from lsst/lsst-texmf.