### PR TITLE
Centralize nitpick ignore patterns

### DIFF
--- a/changelog.d/20250711_114447_jsick_nitpick_ignore.md
+++ b/changelog.d/20250711_114447_jsick_nitpick_ignore.md
@@ -1,0 +1,17 @@
+<!-- Delete the sections that don't apply -->
+
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+- Improved and extended the nitpick ignore configurations for both user guides and technotes. The new configuration engine uses a common set of utility functions to generate the ignore patterns. Second, Documenteer makes better use of regex patterns to ignore linking issues to APIs that are not documented with Sphinx, such as `fastapi`, `httpx`, and `pydantic`. This should reduce the number of nitpick warnings in user guides and technotes, and generally reduce the need for manual nitpick ignores in projects.
+
+### Bug fixes
+
+-
+
+### Other changes
+
+-

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -8,10 +8,12 @@ from git import Repo
 from sphinx.errors import ConfigError
 
 __all__ = [
-    "get_asset_path",
-    "extend_static_paths_with_asset_extension",
-    "get_template_dir",
     "GitRepository",
+    "extend_static_paths_with_asset_extension",
+    "get_asset_path",
+    "get_common_nitpick_ignore",
+    "get_common_nitpick_ignore_regex",
+    "get_template_dir",
 ]
 
 
@@ -144,3 +146,69 @@ def extend_excludes_for_non_index_source(
     for p in cwd.glob(f"**/*.{extension}"):
         if p.name != f"index.{extension}":
             exclude_patterns.append(str(p.relative_to(cwd)))  # noqa: PERF401
+
+
+def get_common_nitpick_ignore() -> list[tuple[str, str]]:
+    """Get a list of common nitpick ignore tuples for Sphinx.
+
+    This is useful for ignoring common warnings that are not relevant to
+    the documentation project.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        A list of tuples where each tuple contains the domain and the target
+        to ignore.
+    """
+    return [
+        # Ignore missing cross-references for modules that don't provide
+        # intersphinx.  The documentation itself should use double-quotes
+        # instead of single-quotes to not generate a reference, but automatic
+        # references are generated from the type signatures and can't be
+        # avoided.
+        ("py:obj", "ConfigDict"),
+        (
+            "py:obj",
+            "safir.pydantic.validate_exactly_one_of.<locals>.validator",
+        ),
+        # asyncio.Lock is documented, and that's what all the code references,
+        # but the combination of Sphinx extensions we're using confuse
+        # themselves and there doesn't seem to be any way to fix this.
+        ("py:class", "asyncio.locks.Lock"),
+        ("py:class", "pathlib._local.Path"),
+    ]
+
+
+def get_common_nitpick_ignore_regex() -> list[tuple[str, str]]:
+    """Get a list of common nitpick ignore regex tuples for Sphinx.
+
+    This is useful for ignoring common warnings that are not relevant to
+    the documentation project.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        A list of tuples where each tuple contains the domain and the target
+        to ignore.
+    """
+    # These packages aren't documented with Sphinx, so we can't link to them
+    # with intersphinx.
+    packages = [
+        "fastapi",
+        "httpx",
+        "kubernetes_asyncio",
+        "pydantic",
+        "pydantic_settings",
+        "starlette",
+    ]
+    patterns = [("py:*", rf"{package}(?:\..*)?") for package in packages]
+
+    # Additional patterns that are common to ignore.
+    patterns.extend(
+        [
+            # Bug in sphinx.ext.autodoc for pydantic models.
+            ("py:*", r".*\.all fields"),
+        ]
+    )
+
+    return patterns

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-def _get_assert_dir() -> Path:
+def _get_assets_directory() -> Path:
     """Get the absolute path to the Documenteer assets directory."""
     return Path(__file__).parent.joinpath("../assets")
 
@@ -46,7 +46,7 @@ def get_asset_path(name: str) -> str:
            get_asset_path("rubin-titlebar-imagotype-light.svg"),
        ]
     """
-    asset_path = _get_assert_dir().joinpath(name).resolve()
+    asset_path = _get_assets_directory().joinpath(name).resolve()
     if not asset_path.exists():
         raise ConfigError(
             f"Documenteer asset {name!r} does not exist.\n"
@@ -62,7 +62,7 @@ def extend_static_paths_with_asset_extension(
     """Extend a Sphinx ``html_static_path`` configuration list with the
     files of a given extension in Documenteer's assets directory.
     """
-    asset_dir = _get_assert_dir()
+    asset_dir = _get_assets_directory()
     new_paths = [str(p) for p in asset_dir.glob(f"*.{extension}")]
     html_static_path.extend(new_paths)
 

--- a/src/documenteer/conf/guide.py
+++ b/src/documenteer/conf/guide.py
@@ -16,6 +16,10 @@ from documenteer.conf import (
     get_asset_path,
     get_template_dir,
 )
+from documenteer.conf._utils import (
+    get_common_nitpick_ignore,
+    get_common_nitpick_ignore_regex,
+)
 
 # This configuration is broken down into these sections:
 #
@@ -215,52 +219,10 @@ default_role = "py:obj"
 nitpicky = _conf.nitpicky
 
 # Warnings to ignore
-nitpick_ignore: list[tuple[str, str]] = [
-    # Ignore missing cross-references for modules that don't provide
-    # intersphinx.  The documentation itself should use double-quotes instead
-    # of single-quotes to not generate a reference, but automatic references
-    # are generated from the type signatures and can't be avoided.
-    ("py:class", "fastapi.applications.FastAPI"),
-    ("py:class", "fastapi.datastructures.DefaultPlaceholder"),
-    ("py:class", "fastapi.exceptions.HTTPException"),
-    ("py:class", "fastapi.params.Depends"),
-    ("py:class", "fastapi.routing.APIRoute"),
-    ("py:class", "httpx.AsyncClient"),
-    ("py:exc", "fastapi.HTTPException"),
-    ("py:exc", "fastapi.exceptions.RequestValidationError"),
-    ("py:exc", "httpx.HTTPError"),
-    ("py:obj", "ConfigDict"),
-    ("py:obj", "fastapi.routing.APIRoute"),
-    ("py:class", "kubernetes_asyncio.client.api_client.ApiClient"),
-    ("py:class", "pydantic.main.BaseModel"),
-    ("py:class", "pydantic.networks.AnyHttpUrl"),
-    ("py:class", "pydantic.networks.IPvAnyNetwork"),
-    ("py:class", "pydantic.types.SecretStr"),
-    ("py:class", "pydantic.utils.Representation"),
-    ("py:class", "pydantic_core._pydantic_core.Url"),
-    ("py:class", "pydantic_core._pydantic_core.ValidationError"),
-    ("py:class", "pydantic_settings.main.BaseSettings"),
-    ("py:class", "pydantic_settings.sources.CliSettingsSource"),
-    ("py:obj", "safir.pydantic.validate_exactly_one_of.<locals>.validator"),
-    ("py:class", "starlette.datastructures.URL"),
-    ("py:class", "starlette.middleware.base.BaseHTTPMiddleware"),
-    ("py:class", "starlette.requests.Request"),
-    ("py:class", "starlette.responses.Response"),
-    ("py:class", "starlette.routing.Route"),
-    ("py:class", "starlette.routing.BaseRoute"),
-    ("py:exc", "starlette.exceptions.HTTPException"),
-    # asyncio.Lock is documented, and that's what all the code references, but
-    # the combination of Sphinx extensions we're using confuse themselves and
-    # there doesn't seem to be any way to fix this.
-    ("py:class", "asyncio.locks.Lock"),
-]
+nitpick_ignore = get_common_nitpick_ignore()
 _conf.append_nitpick_ignore(nitpick_ignore)
 
-nitpick_ignore_regex: list[tuple[str, str]] = [
-    ("py:class", r"kubernetes_asyncio\.client\.models\..*"),
-    # Bug in autodoc_pydantic.
-    ("py:obj", r".*\.all fields"),
-]
+nitpick_ignore_regex = get_common_nitpick_ignore_regex()
 _conf.append_nitpick_ignore_regex(nitpick_ignore_regex)
 
 # A list of paths that contain extra templates (or templates that overwrite

--- a/src/documenteer/conf/technote.py
+++ b/src/documenteer/conf/technote.py
@@ -14,6 +14,8 @@ from documenteer.conf import (
     get_template_dir,
 )
 
+from ._utils import get_common_nitpick_ignore, get_common_nitpick_ignore_regex
+
 # Suppress warnings about deprecated features in future Sphinx versions.
 # This is noise for users because Documenteer itself constrains the Sphinx
 # version.
@@ -119,3 +121,6 @@ if _id is not None:
     html_context["editions_url"] = (  # noqa: F405
         f"https://{_id.lower()}.lsst.io/v/"
     )
+
+nitpick_ignore_regex.extend(get_common_nitpick_ignore_regex())  # noqa: F405
+nitpick_ignore.extend(get_common_nitpick_ignore())  # noqa: F405


### PR DESCRIPTION
Introduce a centralized approach for nitpick ignore patterns to streamline documentation processes and reduce manual configurations.