### PR TITLE
More autodoc/automodapi/autodoc_pydantic workarounds

### DIFF
--- a/changelog.d/20250902_161655_danfuchs_DM_52367.md
+++ b/changelog.d/20250902_161655_danfuchs_DM_52367.md
@@ -1,0 +1,9 @@
+### New features
+
+- Add `sentry_sdk` to default non-intersphinx packages
+- Ignore `TypeAliasType` due to sphinx bug
+- Ignore `asyncio.Event`, it has the same problem as `asyncio.Lock`
+
+### Bug fixes
+
+- Fix `nitpick_ignore_regex` regexes, they weren't being applied due to a missing `.`

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -209,6 +209,8 @@ def get_common_nitpick_ignore_regex() -> list[tuple[str, str]]:
         [
             # Bug in sphinx.ext.autodoc for pydantic models.
             ("py:.*", r".*\.all fields"),
+            # Sphinx bug handling the type keyword
+            ("py:.*", r".*\.TypeAliasType"),
         ]
     )
 

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -200,6 +200,7 @@ def get_common_nitpick_ignore_regex() -> list[tuple[str, str]]:
         "kubernetes_asyncio",
         "pydantic",
         "pydantic_settings",
+        "sentry_sdk",
         "starlette",
     ]
     patterns = [("py:.*", rf"{package}(?:\..*)?") for package in packages]

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -202,13 +202,13 @@ def get_common_nitpick_ignore_regex() -> list[tuple[str, str]]:
         "pydantic_settings",
         "starlette",
     ]
-    patterns = [("py:*", rf"{package}(?:\..*)?") for package in packages]
+    patterns = [("py:.*", rf"{package}(?:\..*)?") for package in packages]
 
     # Additional patterns that are common to ignore.
     patterns.extend(
         [
             # Bug in sphinx.ext.autodoc for pydantic models.
-            ("py:*", r".*\.all fields"),
+            ("py:.*", r".*\.all fields"),
         ]
     )
 

--- a/src/documenteer/conf/_utils.py
+++ b/src/documenteer/conf/_utils.py
@@ -171,10 +171,11 @@ def get_common_nitpick_ignore() -> list[tuple[str, str]]:
             "py:obj",
             "safir.pydantic.validate_exactly_one_of.<locals>.validator",
         ),
-        # asyncio.Lock is documented, and that's what all the code references,
-        # but the combination of Sphinx extensions we're using confuse
-        # themselves and there doesn't seem to be any way to fix this.
+        # asyncio.Lock and asyncio.Event are documented but the combination of
+        # Sphinx extensions we're using confuse themselves and there doesn't
+        # seem to be any way to fix this.
         ("py:class", "asyncio.locks.Lock"),
+        ("py:class", "asyncio.locks.Event"),
         ("py:class", "pathlib._local.Path"),
     ]
 


### PR DESCRIPTION
- Add `sentry_sdk` to default non-intersphinx packages
- Ignore `TypeAliasType` due to sphinx bug
- Fix `nitpick_ignore_regex` regexes, they weren't being applied due to a missing `.`
- Ignore `asyncio.Event`, it has the same problem as `asyncio.Lock`